### PR TITLE
Make the gradle kops deployment tasks a bit more generic.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -218,13 +218,13 @@ task dockerRemoveImage(type: DockerRemoveImage) {
 /**
  * Kubernetes
  */
-task setDevKopsConfig(type: Exec) {
+task kopsConfigSet(type: Exec) {
     executable = 'kops'
-    args = ['export', 'kubecfg', '--state', "${project.kubecfgState}", '--name', "${project.kubecfgDevName}"]
+    args = ['export', 'kubecfg', '--state', "${project.kubecfgState}", '--name', "${project.kubecfgName}"]
 }
 
-task setDevKopsVersion(type: Exec) {
-    dependsOn 'setDevKopsConfig'
+task kopsVersionSet(type: Exec) {
+    dependsOn 'kopsConfigSet'
     // Set the version of the docker container to whatever we just built. If we have not done a release build since the last
     // dev (SNAPSHOT) build, this may be the same as last time, and my not cause the pod to be updated in k8s.
     // The updateDevKops task will force the update to happen each time it is executed
@@ -232,8 +232,8 @@ task setDevKopsVersion(type: Exec) {
     args = ['set', 'image', 'deployment/ap-imrt-iis-deployment', "ap-imrt-iis=${project.dockerTagBase}/ap-imrt-iis:${project.version}"]
 }
 
-task updateDevKops(type: Exec) {
-    dependsOn 'setDevKopsVersion'
+task kopsUpdateDeployment(type: Exec) {
+    dependsOn 'kopsVersionSet'
     // Patch the deployment by changing the date inside the specification. This will cause the pod to be restarted. Since we have
     // the deployment set to always pull the docker image, this will pick up the latest version even if the tag didn't change
     executable = 'kubectl'

--- a/build.gradle
+++ b/build.gradle
@@ -240,3 +240,20 @@ task kopsUpdateDeployment(type: Exec) {
     args = ['patch', 'deployment', 'ap-imrt-iis-deployment', '-p', String.format("{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"%s\"}}}}}", new Date().getTime())]
 }
 
+/**
+ * Save the current build.gradle and gradle.properties file to the build directory.
+ * This will be used during release builds to save the release revision, which is
+ * not available at the end of the build as gradle.properties has been modified to
+ * increment the build version and add the SNAPSHOT tag.
+ *
+ * These files can then be published as an artifact in Bamboo, and used during
+ * deployment builds.
+ */
+task revisionSave(type: Copy) {
+    from '.'
+    into 'build/release'
+    include 'build.gradle'
+    include 'gradle.properties'
+}
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,4 +36,4 @@ dockerHubEmail=
 
 # kubernetes
 kubecfgState=s3://kops-imrt-dev-state-store
-kubecfgDevName=dev.imrt.k8s.local
+kubecfgName=dev.imrt.k8s.local

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/repository/StandardIdRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/repository/StandardIdRepositoryTest.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StandardIdRespositoryTest extends BaseIntegrationTest {
+public class StandardIdRepositoryTest extends BaseIntegrationTest {
 
     @Autowired
     private StandardIdRepository standardIdRepository;

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/repository/StimLinkRepositoryTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/repository/StimLinkRepositoryTest.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class StimLinkRespositoryTest extends BaseIntegrationTest {
+public class StimLinkRepositoryTest extends BaseIntegrationTest {
 
     @Autowired
     private StimLinkRepository stimLinkRepository;


### PR DESCRIPTION
Also rename a couple of tests that had typos in their names.