### PR TITLE
IMRT-322: Set charset for unit test

### DIFF
--- a/src/test/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageRecovererTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageRecovererTest.java
@@ -10,6 +10,8 @@ import org.slf4j.Logger;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageBuilder;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
@@ -28,7 +30,7 @@ public class ItemUpdateMessageRecovererTest {
 
     @Test
     public void shouldLogError() {
-        final byte[] mockPayload = "{ 'id' : 42 }".getBytes();
+        final byte[] mockPayload = "{ 'id' : 42 }".getBytes(StandardCharsets.UTF_8);
         final Message mockMessage = MessageBuilder
                 .withBody(mockPayload)
                 .build();


### PR DESCRIPTION
Set the charset for the call to `getBytes()`.  This resolves the `findBugs` issue, which complains if the charset isn't set.

