### PR TITLE
ELA content domain now stored within primary content domain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ configurations {
 dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.hibernate:hibernate-java8:5.0.12.Final'
-    compile 'org.opentestsystem.ap:ap-common:0.3.35'
+    compile 'org.opentestsystem.ap:ap-common:0.3.36'
     compile 'org.opentestsystem.ap:ap-imrt-common:0.1.23'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.hibernate:hibernate-java8:5.0.12.Final'
     compile 'org.opentestsystem.ap:ap-common:0.3.36'
-    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.23'
+    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.24'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.cloud:spring-cloud-starter-config'

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemRevisionImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemRevisionImpl.java
@@ -87,7 +87,7 @@ public final class ItemRevisionImpl implements ItemRevision {
         // Metadata may be null if this is a tutorial item
         if (metadata != null) {
             baseItem.setSubject(StringUtils.defaultString(metadata.getSubject()));
-            baseItem.setGrade(StringUtils.defaultString(metadata.getGrade()));
+            baseItem.setGrade(StringUtils.defaultString(metadata.getIntendedGrade()));
             baseItem.setDepthOfKnowledge(StringUtils.defaultString(metadata.getDepthOfKnowledge()));
             baseItem.setOrganizationTypeId(StringUtils.defaultString(metadata.getOrganizationTypeId()));
             baseItem.setOrganizationName(StringUtils.defaultString(metadata.getOrganizationName()));
@@ -129,21 +129,21 @@ public final class ItemRevisionImpl implements ItemRevision {
         }
 
         item.setPrimaryClaim(StringUtils.defaultString(metadata.getPrimaryClaim()));
-        item.setPrimaryTarget(StringUtils.defaultString(metadata.getPrimaryAssessmentTarget()));
+        item.setPrimaryTarget(StringUtils.defaultString(metadata.getPrimaryTarget()));
         item.setPrimaryCommonCoreStandard(StringUtils.defaultString(metadata.getPrimaryCommonCoreStandard()));
         item.setPrimaryContentDomain(StringUtils.defaultString(metadata.getPrimaryContentDomain()));
         item.setSecondaryClaim(StringUtils.defaultString(metadata.getSecondaryClaim()));
         item.setSecondaryCommonCoreStandard(StringUtils.defaultString(metadata.getSecondaryCommonCoreStandard()));
         item.setSecondaryContentDomain(StringUtils.defaultString(metadata.getSecondaryContentDomain()));
-        item.setSecondaryTarget(StringUtils.defaultString(metadata.getSecondaryAssessmentTarget()));
+        item.setSecondaryTarget(StringUtils.defaultString(metadata.getSecondaryTarget()));
         item.setTertiaryClaim(StringUtils.defaultString(metadata.getTertiaryClaim()));
         item.setTertiaryCommonCoreStandard(StringUtils.defaultString(metadata.getTertiaryCommonCoreStandard()));
         item.setTertiaryContentDomain(StringUtils.defaultString(metadata.getTertiaryContentDomain()));
-        item.setTertiaryTarget(StringUtils.defaultString(metadata.getTertiaryAssessmentTarget()));
+        item.setTertiaryTarget(StringUtils.defaultString(metadata.getTertiaryTarget()));
         item.setQuaternaryClaim(StringUtils.defaultString(metadata.getQuaternaryClaim()));
         item.setQuaternaryCommonCoreStandard(StringUtils.defaultString(metadata.getQuaternaryCommonCoreStandard()));
         item.setQuaternaryContentDomain(StringUtils.defaultString(metadata.getQuaternaryContentDomain()));
-        item.setQuaternaryTarget(StringUtils.defaultString(metadata.getQuaternaryAssessmentTarget()));
+        item.setQuaternaryTarget(StringUtils.defaultString(metadata.getQuaternaryTarget()));
     }
 
     /**

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemRevisionImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemRevisionImpl.java
@@ -129,20 +129,8 @@ public final class ItemRevisionImpl implements ItemRevision {
 
         item.setPrimaryClaim(StringUtils.defaultString(metadata.getPrimaryClaim()));
         item.setPrimaryTarget(StringUtils.defaultString(metadata.getPrimaryAssessmentTarget()));
-
         item.setPrimaryCommonCoreStandard(StringUtils.defaultString(metadata.getPrimaryCommonCoreStandard()));
-
-        //ELA content domain is stored in a different field than MATH
-        if (ItemConstants.ItemSubject.SUBJECT_ELA.equalsIgnoreCase(metadata.getSubject())) {
-            item.setPrimaryContentDomain(StringUtils.defaultString(metadata.getContentDomain()));
-        } else {
-            item.setPrimaryContentDomain(StringUtils.defaultString(metadata.getPrimaryContentDomain()));
-        }
-
-        updateNonPrimaryStandardIds(item);
-    }
-
-    private void updateNonPrimaryStandardIds(BaseItem item) {
+        item.setPrimaryContentDomain(StringUtils.defaultString(metadata.getPrimaryContentDomain()));
         item.setSecondaryClaim(StringUtils.defaultString(metadata.getSecondaryClaim()));
         item.setSecondaryCommonCoreStandard(StringUtils.defaultString(metadata.getSecondaryCommonCoreStandard()));
         item.setSecondaryContentDomain(StringUtils.defaultString(metadata.getSecondaryContentDomain()));

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/service/ItemRevisionImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/service/ItemRevisionImplTest.java
@@ -8,7 +8,6 @@ import org.opentestsystem.ap.common.model.AbstractAssessmentItemCore;
 import org.opentestsystem.ap.common.model.AbstractItem;
 import org.opentestsystem.ap.common.model.AssessmentItemCore;
 import org.opentestsystem.ap.common.model.Item;
-import org.opentestsystem.ap.common.model.ItemConstants;
 import org.opentestsystem.ap.common.model.ItemMetadata;
 import org.opentestsystem.ap.common.model.StimItemCore;
 import org.opentestsystem.ap.imrt.common.model.BaseItem;
@@ -323,25 +322,21 @@ public class ItemRevisionImplTest {
         assertThat(item.getPrimaryCommonCoreStandard()).isEqualTo(metadata.getPrimaryCommonCoreStandard());
         assertThat(item.getPrimaryTarget()).isEqualTo(metadata.getPrimaryAssessmentTarget());
 
-        if (ItemConstants.ItemSubject.SUBJECT_ELA.equals(metadata.getSubject())) {
-            assertThat(item.getPrimaryContentDomain()).isEqualTo(metadata.getContentDomain());
-        } else {
-            assertThat(item.getPrimaryContentDomain()).isEqualTo(metadata.getPrimaryContentDomain());
-            assertThat(item.getSecondaryClaim()).isEqualTo(metadata.getSecondaryClaim());
-            assertThat(item.getSecondaryCommonCoreStandard()).isEqualTo(metadata.getSecondaryCommonCoreStandard());
-            assertThat(item.getSecondaryTarget()).isEqualTo(metadata.getSecondaryAssessmentTarget());
-            assertThat(item.getSecondaryContentDomain()).isEqualTo(metadata.getSecondaryContentDomain());
+        assertThat(item.getPrimaryContentDomain()).isEqualTo(metadata.getPrimaryContentDomain());
+        assertThat(item.getSecondaryClaim()).isEqualTo(metadata.getSecondaryClaim());
+        assertThat(item.getSecondaryCommonCoreStandard()).isEqualTo(metadata.getSecondaryCommonCoreStandard());
+        assertThat(item.getSecondaryTarget()).isEqualTo(metadata.getSecondaryAssessmentTarget());
+        assertThat(item.getSecondaryContentDomain()).isEqualTo(metadata.getSecondaryContentDomain());
 
-            assertThat(item.getTertiaryClaim()).isEqualTo(metadata.getTertiaryClaim());
-            assertThat(item.getTertiaryCommonCoreStandard()).isEqualTo(metadata.getTertiaryCommonCoreStandard());
-            assertThat(item.getTertiaryTarget()).isEqualTo(metadata.getTertiaryAssessmentTarget());
-            assertThat(item.getTertiaryContentDomain()).isEqualTo(metadata.getTertiaryContentDomain());
+        assertThat(item.getTertiaryClaim()).isEqualTo(metadata.getTertiaryClaim());
+        assertThat(item.getTertiaryCommonCoreStandard()).isEqualTo(metadata.getTertiaryCommonCoreStandard());
+        assertThat(item.getTertiaryTarget()).isEqualTo(metadata.getTertiaryAssessmentTarget());
+        assertThat(item.getTertiaryContentDomain()).isEqualTo(metadata.getTertiaryContentDomain());
 
-            assertThat(item.getQuaternaryClaim()).isEqualTo(metadata.getQuaternaryClaim());
-            assertThat(item.getQuaternaryCommonCoreStandard()).isEqualTo(metadata.getQuaternaryCommonCoreStandard());
-            assertThat(item.getQuaternaryTarget()).isEqualTo(metadata.getQuaternaryAssessmentTarget());
-            assertThat(item.getQuaternaryContentDomain()).isEqualTo(metadata.getQuaternaryContentDomain());
-        }
+        assertThat(item.getQuaternaryClaim()).isEqualTo(metadata.getQuaternaryClaim());
+        assertThat(item.getQuaternaryCommonCoreStandard()).isEqualTo(metadata.getQuaternaryCommonCoreStandard());
+        assertThat(item.getQuaternaryTarget()).isEqualTo(metadata.getQuaternaryAssessmentTarget());
+        assertThat(item.getQuaternaryContentDomain()).isEqualTo(metadata.getQuaternaryContentDomain());
     }
 
     private void validateEmptyStandardId(BaseItem item) {

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/service/ItemRevisionImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/service/ItemRevisionImplTest.java
@@ -124,7 +124,7 @@ public class ItemRevisionImplTest {
     public void fromElaTargetOnlyStandardId() throws IOException {
         Item item = getItemFromJsonFile("json/ela-no-standard-id.json");
         ItemMetadata metadata = item.getCore().getMetadata();
-        metadata.setPrimaryAssessmentTarget("Target");
+        metadata.setPrimaryTarget("Target");
 
         ItemRevision revision = runTestCore(item, metadata, null);
 
@@ -135,7 +135,7 @@ public class ItemRevisionImplTest {
     public void fromElaDomainOnlyStandardId() throws IOException {
         Item item = getItemFromJsonFile("json/ela-no-standard-id.json");
         ItemMetadata metadata = item.getCore().getMetadata();
-        metadata.setContentDomain("Domain");
+        metadata.setPrimaryContentDomain("Domain");
 
         ItemRevision revision = runTestCore(item, metadata, null);
 
@@ -237,10 +237,10 @@ public class ItemRevisionImplTest {
     public void mathAllTargetOnlyStandardId() throws IOException {
         Item item = getItemFromJsonFile("json/math-no-standard-ids.json");
         ItemMetadata metadata = item.getCore().getMetadata();
-        metadata.setPrimaryAssessmentTarget("Target");
-        metadata.setSecondaryAssessmentTarget("Target");
-        metadata.setTertiaryAssessmentTarget("Target");
-        metadata.setQuaternaryAssessmentTarget("Target");
+        metadata.setPrimaryTarget("Target");
+        metadata.setSecondaryTarget("Target");
+        metadata.setTertiaryTarget("Target");
+        metadata.setQuaternaryTarget("Target");
 
         ItemRevision revision = runTestCore(item, metadata, null);
 
@@ -318,22 +318,22 @@ public class ItemRevisionImplTest {
     private void validateStandardId(ItemMetadata metadata, BaseItem item) {
         assertThat(item.getPrimaryClaim()).isEqualTo(metadata.getPrimaryClaim());
         assertThat(item.getPrimaryCommonCoreStandard()).isEqualTo(metadata.getPrimaryCommonCoreStandard());
-        assertThat(item.getPrimaryTarget()).isEqualTo(metadata.getPrimaryAssessmentTarget());
+        assertThat(item.getPrimaryTarget()).isEqualTo(metadata.getPrimaryTarget());
 
         assertThat(item.getPrimaryContentDomain()).isEqualTo(metadata.getPrimaryContentDomain());
         assertThat(item.getSecondaryClaim()).isEqualTo(metadata.getSecondaryClaim());
         assertThat(item.getSecondaryCommonCoreStandard()).isEqualTo(metadata.getSecondaryCommonCoreStandard());
-        assertThat(item.getSecondaryTarget()).isEqualTo(metadata.getSecondaryAssessmentTarget());
+        assertThat(item.getSecondaryTarget()).isEqualTo(metadata.getSecondaryTarget());
         assertThat(item.getSecondaryContentDomain()).isEqualTo(metadata.getSecondaryContentDomain());
 
         assertThat(item.getTertiaryClaim()).isEqualTo(metadata.getTertiaryClaim());
         assertThat(item.getTertiaryCommonCoreStandard()).isEqualTo(metadata.getTertiaryCommonCoreStandard());
-        assertThat(item.getTertiaryTarget()).isEqualTo(metadata.getTertiaryAssessmentTarget());
+        assertThat(item.getTertiaryTarget()).isEqualTo(metadata.getTertiaryTarget());
         assertThat(item.getTertiaryContentDomain()).isEqualTo(metadata.getTertiaryContentDomain());
 
         assertThat(item.getQuaternaryClaim()).isEqualTo(metadata.getQuaternaryClaim());
         assertThat(item.getQuaternaryCommonCoreStandard()).isEqualTo(metadata.getQuaternaryCommonCoreStandard());
-        assertThat(item.getQuaternaryTarget()).isEqualTo(metadata.getQuaternaryAssessmentTarget());
+        assertThat(item.getQuaternaryTarget()).isEqualTo(metadata.getQuaternaryTarget());
         assertThat(item.getQuaternaryContentDomain()).isEqualTo(metadata.getQuaternaryContentDomain());
     }
 
@@ -407,7 +407,7 @@ public class ItemRevisionImplTest {
 
         if (metadata != null) {
             assertThat(imrtItem.getSubject()).isEqualTo(metadata.getSubject());
-            assertThat(imrtItem.getGrade()).isEqualTo(metadata.getGrade());
+            assertThat(imrtItem.getGrade()).isEqualTo(metadata.getIntendedGrade());
             assertThat(imrtItem.getDepthOfKnowledge()).isEqualTo(metadata.getDepthOfKnowledge());
             assertThat(imrtItem.getContentTaskModel()).isEqualTo(metadata.getContentTaskModel());
             assertThat(imrtItem.getItemAuthor()).isEqualTo(metadata.getItemAuthor());

--- a/src/test/resources/json/ela-no-standard-id.json
+++ b/src/test/resources/json/ela-no-standard-id.json
@@ -34,7 +34,7 @@
 
       "depthOfKnowledge" : "2",
 
-      "grade" : "6",
+      "intendedGrade" : "6",
 
       "algebraDescriptor1" : "",
 


### PR DESCRIPTION
IAT is going to store content domain the same for Math and ELA items since the field is the same.  This can't be merged until IAT deploys to develop.