### PR TITLE
IMRT-353:  Feature/item sync logging

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
@@ -9,6 +9,8 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 /**
  * A {@link org.springframework.batch.core.JobExecutionListener} that prevents the item synchronization job from running
  * more than one instance at a time.
@@ -36,29 +38,32 @@ public class ItemSynchronizationJobExecutionListener implements JobExecutionList
 
     @Override
     public void afterJob(final JobExecution jobExecution) {
-        // Release the lock and log completion
+        // Log completion of the item synchronization process.  If the job ran into an exception, capture the stack
+        // trace.
+        String exitStatusMessage;
+        if (jobExecution.getAllFailureExceptions().isEmpty()) {
+            final Optional<ItemSynchronizationResponse> response =
+                    Optional.ofNullable((ItemSynchronizationResponse) jobExecution.getExecutionContext().get(ItemSynchronizationResponse.EXECUTION_CONTEXT_DATA_KEY));
+
+            exitStatusMessage = response.map(ItemSynchronizationResponse::toString)
+                    .orElse(String.format("No response data from ItemSynchronizationService execution for Job execution id: %d.", jobExecution.getId()));
+        } else {
+            final String[] exceptionMessages = jobExecution.getAllFailureExceptions().stream()
+                    .map(throwable -> String.format("%s: %s", throwable.getMessage(), ExceptionUtils.getStackTrace(throwable)))
+                    .toArray(String[]::new);
+            exitStatusMessage = String.join("\n", exceptionMessages);
+        }
+
+        jobExecution.setExitStatus(new ExitStatus(jobExecution.getExitStatus().getExitCode(), exitStatusMessage));
+
+        logger.info("Item Synchronization Process complete.  Job execution id: {}, exit status code: {}, exit message: {}",
+                jobExecution.getId(),
+                jobExecution.getExitStatus().getExitCode(),
+                exitStatusMessage);
+
+        // Release the lock
         synchronized (jobExecution) {
             if (jobExecution.equals(activeJob)) {
-                final ItemSynchronizationResponse response =
-                        (ItemSynchronizationResponse) jobExecution.getExecutionContext().get(ItemSynchronizationResponse.EXECUTION_CONTEXT_DATA_KEY);
-
-                String exitStatusMessage;
-                if (jobExecution.getAllFailureExceptions().isEmpty()) {
-                    exitStatusMessage = response.toString();
-                } else {
-                    final String[] exceptionMessages = jobExecution.getAllFailureExceptions().stream()
-                            .map(throwable -> String.format("%s: %s", throwable.getMessage(), ExceptionUtils.getStackTrace(throwable)))
-                            .toArray(String[]::new);
-                    exitStatusMessage = String.join("\n", exceptionMessages);
-                }
-
-                jobExecution.setExitStatus(new ExitStatus(jobExecution.getExitStatus().getExitCode(), exitStatusMessage));
-
-                logger.info("Item Synchronization Process complete.  Job execution id: {}, exit status code: {}, exit message: {}",
-                        activeJob.getId(),
-                        activeJob.getExitStatus().getExitCode(),
-                        exitStatusMessage);
-
                 activeJob = null;
             }
         }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
@@ -44,9 +44,7 @@ public class ItemSynchronizationJobExecutionListener implements JobExecutionList
 
                 String exitStatusMessage;
                 if (jobExecution.getAllFailureExceptions().isEmpty()) {
-                    exitStatusMessage = String.format("Total item bank ids: %d, number of items requiring project webhook: %d",
-                            response.getNumberOfItembankIds(),
-                            response.getNumberOfItemsWithoutWebhook());
+                    exitStatusMessage = response.toString();
                 } else {
                     final String[] exceptionMessages = jobExecution.getAllFailureExceptions().stream()
                             .map(throwable -> String.format("%s: %s", throwable.getMessage(), ExceptionUtils.getStackTrace(throwable)))

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
@@ -1,8 +1,10 @@
 package org.opentestsystem.ap.imrt.iis.batch;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.opentestsystem.ap.imrt.iis.model.ItemSynchronizationResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.stereotype.Component;
@@ -23,11 +25,11 @@ public class ItemSynchronizationJobExecutionListener implements JobExecutionList
         // the new job request.
         synchronized (jobExecution) {
             if (activeJob != null && activeJob.isRunning()) {
-                logger.warn("An Item Synchronization Process with Job id: {} is already running.  Wait for this job to complete before starting another one.", activeJob.getJobId());
+                logger.warn("An Item Synchronization Process with Job execution id: {} is already running.  Wait for this job to complete before starting another one.", activeJob.getId());
                 jobExecution.stop();
             } else {
                 activeJob = jobExecution;
-                logger.info("Item Synchronization Process starting.  Job id: {}", activeJob.getJobId());
+                logger.info("Item Synchronization Process starting.  Job execution id: {}", activeJob.getId());
             }
         }
     }
@@ -37,19 +39,27 @@ public class ItemSynchronizationJobExecutionListener implements JobExecutionList
         // Release the lock and log completion
         synchronized (jobExecution) {
             if (jobExecution.equals(activeJob)) {
-                logger.info("Item Synchronization Process complete.  Job id: {}, batch status: {}, exit status code: {}",
-                        activeJob.getJobId(),
-                        activeJob.getStatus().getBatchStatus(),
-                        activeJob.getExitStatus().getExitCode());
-
                 final ItemSynchronizationResponse response =
                         (ItemSynchronizationResponse) jobExecution.getExecutionContext().get(ItemSynchronizationResponse.EXECUTION_CONTEXT_DATA_KEY);
-                final String exitStatusMessage =
-                        String.format("Total item bank ids: %d, number of items requiring project webhook: %d",
-                                response.getNumberOfItembankIds(),
-                                response.getNumberOfItemsWithoutWebhook());
 
-                jobExecution.getExitStatus().addExitDescription(exitStatusMessage);
+                String exitStatusMessage;
+                if (jobExecution.getAllFailureExceptions().isEmpty()) {
+                    exitStatusMessage = String.format("Total item bank ids: %d, number of items requiring project webhook: %d",
+                            response.getNumberOfItembankIds(),
+                            response.getNumberOfItemsWithoutWebhook());
+                } else {
+                    final String[] exceptionMessages = jobExecution.getAllFailureExceptions().stream()
+                            .map(throwable -> String.format("%s: %s", throwable.getMessage(), ExceptionUtils.getStackTrace(throwable)))
+                            .toArray(String[]::new);
+                    exitStatusMessage = String.join("\n", exceptionMessages);
+                }
+
+                jobExecution.setExitStatus(new ExitStatus(jobExecution.getExitStatus().getExitCode(), exitStatusMessage));
+
+                logger.info("Item Synchronization Process complete.  Job execution id: {}, exit status code: {}, exit message: {}",
+                        activeJob.getId(),
+                        activeJob.getExitStatus().getExitCode(),
+                        exitStatusMessage);
 
                 activeJob = null;
             }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationJobExecutionListener.java
@@ -1,5 +1,8 @@
 package org.opentestsystem.ap.imrt.iis.batch;
 
+import org.opentestsystem.ap.imrt.iis.model.ItemSynchronizationResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.stereotype.Component;
@@ -12,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class ItemSynchronizationJobExecutionListener implements JobExecutionListener {
     // The active job execution, which will act as a lock.
     private JobExecution activeJob;
+    private static final Logger logger = LoggerFactory.getLogger(ItemSynchronizationJobExecutionListener.class);
 
     @Override
     public void beforeJob(final JobExecution jobExecution) {
@@ -19,18 +23,34 @@ public class ItemSynchronizationJobExecutionListener implements JobExecutionList
         // the new job request.
         synchronized (jobExecution) {
             if (activeJob != null && activeJob.isRunning()) {
+                logger.warn("An Item Synchronization Process with Job id: {} is already running.  Wait for this job to complete before starting another one.", activeJob.getJobId());
                 jobExecution.stop();
             } else {
                 activeJob = jobExecution;
+                logger.info("Item Synchronization Process starting.  Job id: {}", activeJob.getJobId());
             }
         }
     }
 
     @Override
     public void afterJob(final JobExecution jobExecution) {
-        // Release the lock
+        // Release the lock and log completion
         synchronized (jobExecution) {
             if (jobExecution.equals(activeJob)) {
+                logger.info("Item Synchronization Process complete.  Job id: {}, batch status: {}, exit status code: {}",
+                        activeJob.getJobId(),
+                        activeJob.getStatus().getBatchStatus(),
+                        activeJob.getExitStatus().getExitCode());
+
+                final ItemSynchronizationResponse response =
+                        (ItemSynchronizationResponse) jobExecution.getExecutionContext().get(ItemSynchronizationResponse.EXECUTION_CONTEXT_DATA_KEY);
+                final String exitStatusMessage =
+                        String.format("Total item bank ids: %d, number of items requiring project webhook: %d",
+                                response.getNumberOfItembankIds(),
+                                response.getNumberOfItemsWithoutWebhook());
+
+                jobExecution.getExitStatus().addExitDescription(exitStatusMessage);
+
                 activeJob = null;
             }
         }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationTasklet.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationTasklet.java
@@ -1,5 +1,6 @@
 package org.opentestsystem.ap.imrt.iis.batch;
 
+import org.opentestsystem.ap.imrt.iis.model.ItemSynchronizationResponse;
 import org.opentestsystem.ap.imrt.iis.service.ItemSynchronizationService;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
@@ -19,7 +20,11 @@ public class ItemSynchronizationTasklet implements Tasklet {
 
     @Override
     public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
-        itemSynchronizationService.synchronize();
+        final ItemSynchronizationResponse response = itemSynchronizationService.synchronize();
+
+        chunkContext.getStepContext()
+                .getJobExecutionContext()
+                .put(ItemSynchronizationResponse.EXECUTION_CONTEXT_DATA_KEY, response);
 
         return RepeatStatus.FINISHED;
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationTasklet.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/batch/ItemSynchronizationTasklet.java
@@ -22,8 +22,13 @@ public class ItemSynchronizationTasklet implements Tasklet {
     public RepeatStatus execute(final StepContribution contribution, final ChunkContext chunkContext) throws Exception {
         final ItemSynchronizationResponse response = itemSynchronizationService.synchronize();
 
+        // Update the job's execution context with the response from the item synchronization service.  This allows the
+        // Job access to the results of this tasklet, which the job can then use for logging, recording the exit message,
+        // etc.
         chunkContext.getStepContext()
-                .getJobExecutionContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext()
                 .put(ItemSynchronizationResponse.EXECUTION_CONTEXT_DATA_KEY, response);
 
         return RepeatStatus.FINISHED;

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemSynchronizationResponse.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemSynchronizationResponse.java
@@ -1,0 +1,31 @@
+package org.opentestsystem.ap.imrt.iis.model;
+
+/**
+ * Report the number of items affected by the item synchronization process.
+ */
+public class ItemSynchronizationResponse {
+    private final int numberOfItemsWithoutWebhook;
+    private final int numberOfItembankIds;
+    public static final String EXECUTION_CONTEXT_DATA_KEY = "resposne";
+
+    public ItemSynchronizationResponse(final int numberOfItemsWithoutProjectWebhook, final int numberOfProjectIds) {
+        this.numberOfItemsWithoutWebhook = numberOfItemsWithoutProjectWebhook;
+        this.numberOfItembankIds = numberOfProjectIds;
+    }
+
+    /**
+     * @return The number of items that did not have a project webhook, thus had a project webhook as part of the item
+     * synchronization process.
+     */
+    public int getNumberOfItemsWithoutWebhook() {
+        return numberOfItemsWithoutWebhook;
+    }
+
+    /**
+     * @return The total number of item bank ids fetched from source control and processed by the item synchronization
+     * process.
+     */
+    public int getNumberOfItembankIds() {
+        return numberOfItembankIds;
+    }
+}

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemSynchronizationResponse.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/model/ItemSynchronizationResponse.java
@@ -28,4 +28,12 @@ public class ItemSynchronizationResponse {
     public int getNumberOfItembankIds() {
         return numberOfItembankIds;
     }
+
+
+    @Override
+    public String toString() {
+        return String.format("Total item bank ids: %d, number of items requiring project webhook: %d",
+                getNumberOfItembankIds(),
+                getNumberOfItemsWithoutWebhook());
+    }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationService.java
@@ -1,7 +1,9 @@
 package org.opentestsystem.ap.imrt.iis.service;
 
+import org.opentestsystem.ap.imrt.iis.model.ItemSynchronizationResponse;
+
 import java.time.Instant;
 
 public interface ItemSynchronizationService {
-    void synchronize();
+    ItemSynchronizationResponse synchronize();
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceImpl.java
@@ -28,11 +28,11 @@ public class ItemSynchronizationServiceImpl implements ItemSynchronizationServic
     @Override
     public ItemSynchronizationResponse synchronize() {
         final Instant getProjectIdsStartTime = Instant.now();
-        logger.info("getting item bank ids from source control");
+        logger.debug("getting item bank ids from source control");
 
         final List<Integer> allItemBankIds = itemBankClient.getAllItemBankIds();
 
-        logger.info("retrieved {} item bank ids from source control in {} seconds",
+        logger.debug("retrieved {} item bank ids from source control in {} seconds",
                 allItemBankIds.size(),
                 Duration.between(getProjectIdsStartTime, Instant.now()).getSeconds());
 

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceImpl.java
@@ -28,15 +28,15 @@ public class ItemSynchronizationServiceImpl implements ItemSynchronizationServic
     @Override
     public ItemSynchronizationResponse synchronize() {
         final Instant getProjectIdsStartTime = Instant.now();
-        logger.info("getting project ids");
+        logger.info("getting item bank ids from source control");
 
         final List<Integer> allItemBankIds = itemBankClient.getAllItemBankIds();
 
-        logger.info("retrieved {} project ids from source control in {} seconds",
+        logger.info("retrieved {} item bank ids from source control in {} seconds",
                 allItemBankIds.size(),
                 Duration.between(getProjectIdsStartTime, Instant.now()).getSeconds());
 
-        int numberOfItemsWithoutoWebhook = 0;
+        int numberOfItemsWithoutoWebhook = 10;
         for (final Integer projectId : allItemBankIds) {
             // If the project does not any webhooks in place or if the project does not have any webhooks that match
             // IMRT's webhook URL configuration, create one.

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceImpl.java
@@ -2,15 +2,21 @@ package org.opentestsystem.ap.imrt.iis.service;
 
 import org.opentestsystem.ap.imrt.iis.client.ItemBankClient;
 import org.opentestsystem.ap.imrt.iis.client.ItemEventListener;
+import org.opentestsystem.ap.imrt.iis.model.ItemSynchronizationResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 @Service
 public class ItemSynchronizationServiceImpl implements ItemSynchronizationService {
     private final ItemBankClient itemBankClient;
     private final ItemEventListener itemEventListener;
+    private static final Logger logger = LoggerFactory.getLogger(ItemSynchronizationServiceImpl.class);
 
     @Autowired
     public ItemSynchronizationServiceImpl(final ItemBankClient itemBankClient,
@@ -20,17 +26,28 @@ public class ItemSynchronizationServiceImpl implements ItemSynchronizationServic
     }
 
     @Override
-    public void synchronize() {
-        final List<Integer> projectIds = itemBankClient.getAllItemBankIds();
+    public ItemSynchronizationResponse synchronize() {
+        final Instant getProjectIdsStartTime = Instant.now();
+        logger.info("getting project ids");
 
-        for (final Integer projectId : projectIds) {
+        final List<Integer> allItemBankIds = itemBankClient.getAllItemBankIds();
+
+        logger.info("retrieved {} project ids from source control in {} seconds",
+                allItemBankIds.size(),
+                Duration.between(getProjectIdsStartTime, Instant.now()).getSeconds());
+
+        int numberOfItemsWithoutoWebhook = 0;
+        for (final Integer projectId : allItemBankIds) {
             // If the project does not any webhooks in place or if the project does not have any webhooks that match
             // IMRT's webhook URL configuration, create one.
             if (!itemBankClient.isProjectMonitored(projectId)) {
+                numberOfItemsWithoutoWebhook++;
                 itemEventListener.onCreateItem(projectId);
             }
 
             itemEventListener.onUpdateItem(projectId);
         }
+
+        return new ItemSynchronizationResponse(numberOfItemsWithoutoWebhook, allItemBankIds.size());
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/service/ItemSynchronizationServiceTest.java
@@ -5,10 +5,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.opentestsystem.ap.imrt.iis.batch.ItemSynchronizationJobExecutionListener;
 import org.opentestsystem.ap.imrt.iis.client.ItemBankClient;
 import org.opentestsystem.ap.imrt.iis.client.ItemEventListener;
+import org.opentestsystem.ap.imrt.iis.model.ItemSynchronizationResponse;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,12 +42,15 @@ public class ItemSynchronizationServiceTest {
         doNothing().when(mockItemEventListener).onCreateItem(1);
         doNothing().when(mockItemEventListener).onUpdateItem(1);
 
-        itemSynchronizationService.synchronize();
+        final ItemSynchronizationResponse response = itemSynchronizationService.synchronize();
 
         verify(mockItemBankClient).getAllItemBankIds();
         verify(mockItemBankClient).isProjectMonitored(1);
         verify(mockItemEventListener, never()).onCreateItem(1); // webhooks match, so no need to create one
         verify(mockItemEventListener).onUpdateItem(1); // always call update
+
+        assertThat(response.getNumberOfItembankIds()).isEqualTo(1);
+        assertThat(response.getNumberOfItemsWithoutWebhook()).isEqualTo(0);
     }
 
     @Test
@@ -57,11 +63,14 @@ public class ItemSynchronizationServiceTest {
         doNothing().when(mockItemEventListener).onCreateItem(1);
         doNothing().when(mockItemEventListener).onUpdateItem(1);
 
-        itemSynchronizationService.synchronize();
+        final ItemSynchronizationResponse response = itemSynchronizationService.synchronize();
 
         verify(mockItemBankClient).getAllItemBankIds();
         verify(mockItemBankClient).isProjectMonitored(1);
         verify(mockItemEventListener).onCreateItem(1); // no monitoring webhook, so create one
         verify(mockItemEventListener).onUpdateItem(1); // always call update
+
+        assertThat(response.getNumberOfItembankIds()).isEqualTo(1);
+        assertThat(response.getNumberOfItemsWithoutWebhook()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
[IMRT-353](https://jira.fairwaytech.com/browse/IMRT-353):  Additional logging to provide insight into what the item synchronization process is doing (and how long it's doing it for).  Also, the `batch_job_execution.exit_message` field is set in the database when the job's execution completes:

* When successful, the total number of item bank ids and the number of items that needed a webhook will be stored
* When failed, the exception and a stack trace will be recorded