### PR TITLE
Clean up the logging so we don't get double logs in the ingest application

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImpl.java
@@ -53,6 +53,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -90,17 +91,25 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
     @PostConstruct
     public void init() {
         gitLabApi = new GitLabApi(gitlabProperties.getHost(), gitlabProperties.getAccessToken());
+
+        List<Namespace> namespaces;
         try {
-            group = gitLabApi.getNamespaceApi().findNamespaces(gitlabProperties.getGroup()).get(0);
-            systemHookManager.addListener(this);
-            webHookManager.addListener(this);
-            logger.info("GitlabClientImpl Initialized");
+            namespaces = gitLabApi.getNamespaceApi().findNamespaces(gitlabProperties.getGroup());
         } catch (GitLabApiException e) {
-            // Generate an event
-            operationalEventService.serviceError(logger, e, "Unable to find group {}", gitlabProperties.getGroup());
             // Cause spring init to fail
-            throw new GitLabApiRuntimeException(e);
+            throw new GitLabApiRuntimeException(e, String.format("Issue connecting with itembank host %s", gitlabProperties.getHost()));
         }
+
+        if(namespaces.isEmpty()) {
+            throw new IllegalStateException("Unable to find any namespaces for the Gitlab group configured. Group: " + gitlabProperties.getGroup());
+        }
+
+        //Set the group namespace to the first one we find
+        group = namespaces.get(0);
+
+        systemHookManager.addListener(this);
+        webHookManager.addListener(this);
+        logger.info("GitlabClientImpl Initialized");
     }
 
     void setGitLabApi(GitLabApi gitLabApi) {
@@ -195,46 +204,48 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
     @Override
     public List<ItemBankItemRevision> getItemHistory(int itemBankId, ItemGitInformation existingGitInfo) {
         Instant since = existingGitInfo != null ? existingGitInfo.getCurrentCommitDate() : Instant.ofEpochSecond(0);
-        try {
-            String branchName = MASTER_BRANCH_NAME;
-            if (null == existingGitInfo || existingGitInfo.getItem().isBeingCreated()) {
-                // If item.json does not exist on the master branch, find the create branch
-                if (!itemExistsOnMaster(itemBankId)) {
-                    branchName = findCreateBranch(itemBankId, existingGitInfo);
-                }
-            }
-            logger.debug("Using branch {} for itemBankId {}", branchName, itemBankId);
-            // GitLab will only allow returning limited number of commits per page.
-            // To make sure we get them all, we will use paging.
-            Pager<Commit> commitPager = gitLabApi.getCommitsApi().getCommits(itemBankId, branchName,
-                    Date.from(since), null, ITEM_FILE_NAME, MAX_ITEMS_PER_PAGE);
-            List<Commit> commits = Lists.newArrayList();
-            while(commitPager.hasNext()) {
-                 commits.addAll(commitPager.next());
-            }
-            // Gitlab returns the list newest first, we want oldest first
-            Collections.reverse(commits);
-            List<ItemBankItemRevision> itemBankItemRevisions = Lists.newArrayListWithCapacity(commits.size());
-            for (Commit commit : commits) {
-                itemBankItemRevisions.add(generateRevision(itemBankId, commit, branchName));
-            }
-            return itemBankItemRevisions;
-        } catch (GitLabApiException e) {
-            // If there are no commits for item.json, then the above call returns an empty list.
-            // So any exception means something went wrong
-            operationalEventService.serviceError(logger, e, "Unable to retrieve history for itemBankId {} since {}",
-                    itemBankId, since);
-            throw new GitLabApiRuntimeException(e);
+        String branchName = MASTER_BRANCH_NAME;
+        if ((null == existingGitInfo || existingGitInfo.getItem().isBeingCreated()) && !itemExistsOnMaster(itemBankId)) {
+            // If item.json does not exist on the master branch, find the create branch
+            // TODO - Should this throw or should the calling handler get a Not Found or something to indicate it couldn't find the item?
+            branchName = findCreateBranch(itemBankId, existingGitInfo)
+                    .orElseThrow(() -> new GitLabApiRuntimeException("Unable to find create_<user> branch for itemBankId %s", itemBankId));
         }
+        logger.debug("Using branch {} for itemBankId {}", branchName, itemBankId);
+        // GitLab will only allow returning limited number of commits per page.
+        // To make sure we get them all, we will use paging.
+
+        Pager<Commit> commitPager;
+        try {
+            commitPager = gitLabApi.getCommitsApi().getCommits(itemBankId, branchName,
+                    Date.from(since), null, ITEM_FILE_NAME, MAX_ITEMS_PER_PAGE);
+        } catch (GitLabApiException e) {
+            throw new GitLabApiRuntimeException(e, String.format("Unable to retrieve commits for itemBankId %s since %s",
+                    itemBankId, since));
+        }
+
+        List<Commit> commits = Lists.newArrayList();
+        while (commitPager.hasNext()) {
+            commits.addAll(commitPager.next());
+        }
+        // Gitlab returns the list newest first, we want oldest first
+        Collections.reverse(commits);
+        List<ItemBankItemRevision> itemBankItemRevisions = Lists.newArrayListWithCapacity(commits.size());
+        for (Commit commit : commits) {
+            itemBankItemRevisions.add(generateRevision(itemBankId, commit, branchName));
+        }
+        return itemBankItemRevisions;
+
     }
 
     /**
      * Checks to see if item.json exists on the master branch yet
+     *
      * @param itemBankId item bank item id
      * @return true if item.json exists on the master branch, otherwise false
-     * @throws GitLabApiException if an unexpected exception occurs
+     * @throws GitLabApiRuntimeException if an unexpected exception occurs
      */
-    private boolean itemExistsOnMaster(int itemBankId) throws GitLabApiException {
+    private boolean itemExistsOnMaster(int itemBankId) {
         logger.debug("Checking to see if item exists on master for itemBankId {}", itemBankId);
         try {
             gitLabApi.getRepositoryFileApi().getFile(ITEM_FILE_NAME, itemBankId, MASTER_BRANCH_NAME);
@@ -245,55 +256,63 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
                         itemBankId, e.getMessage(), e.getReason(), e.getHttpStatus());
                 return false;
             } else {
-                throw e;
+                throw new GitLabApiRuntimeException(e, "Unexpected error finding item.json for itembank" + itemBankId);
             }
         }
     }
 
     /**
      * Find the name of the create_<user> branch for an itemBank item
-     * @param itemBankId item bank item id
+     *
+     * @param itemBankId      item bank item id
      * @param existingGitInfo existing info, may be null
      * @return the name of the branch
-     * @throws GitLabApiException if an unexpected exception occurs
      */
-    private String findCreateBranch(int itemBankId, ItemGitInformation existingGitInfo) throws GitLabApiException {
+    private Optional<String> findCreateBranch(int itemBankId, ItemGitInformation existingGitInfo) {
         logger.debug("findCreateBranch for itemBankId {}", itemBankId);
         if (null != existingGitInfo) {
             logger.debug("Use existing create branch {} for itemBankId {}", existingGitInfo.getIngestSource(), itemBankId);
-            return existingGitInfo.getIngestSource();
+            return Optional.of(existingGitInfo.getIngestSource());
         }
-        List<Branch> branches = gitLabApi.getRepositoryApi().getBranches(itemBankId);
+
+        List<Branch> branches;
+        try {
+            branches = gitLabApi.getRepositoryApi().getBranches(itemBankId);
+        } catch (GitLabApiException e) {
+            throw new GitLabApiRuntimeException(e, "Error getting branches for itembank id " + itemBankId);
+        }
+
         for (Branch branch : branches) {
             if (branch.getName().startsWith(CREATE_BRANCH_PREFIX)) {
                 logger.debug("Found create branch {} for itemBankId {}", branch.getName(), itemBankId);
-                return branch.getName();
+                return Optional.of(branch.getName());
             }
         }
-        operationalEventService.serviceError(logger, null, "Unable to find create_<user> branch for itemBankId {}",
-                itemBankId);
-        throw new GitLabApiRuntimeException("Unable to find create_<user> branch for itemBankId %s", itemBankId);
+
+
+        return Optional.empty();
     }
 
     @Override
     public List<Integer> getAllItemBankIds() {
         final List<Integer> projectIds = new ArrayList<>();
 
+
+        final Pager<Project> projectPager;
         try {
-            final Pager<Project> projectPager = gitLabApi.getProjectApi().getProjects(MAX_ITEMS_PER_PAGE);
-            while (projectPager.hasNext()) {
-                final List<Project> projects = projectPager.next();
-
-                List<Integer> validProjectIds = projects.stream()
-                        .filter(project -> project.getPathWithNamespace().startsWith(group.getPath()))
-                        .map(Project::getId).collect(Collectors.toList());
-
-                projectIds.addAll(validProjectIds);
-            }
+            projectPager = gitLabApi.getProjectApi().getProjects(MAX_ITEMS_PER_PAGE);
         } catch (GitLabApiException e) {
-            operationalEventService.serviceError(logger, e, "Unable to retrieve project ids from group '{}'", group.getName());
+            throw new GitLabApiRuntimeException(e, "Unable to retrieve project ids from group " + group.getName());
+        }
 
-            throw new GitLabApiRuntimeException(e);
+        while (projectPager.hasNext()) {
+            final List<Project> projects = projectPager.next();
+
+            List<Integer> validProjectIds = projects.stream()
+                    .filter(project -> project.getPathWithNamespace().startsWith(group.getPath()))
+                    .map(Project::getId).collect(Collectors.toList());
+
+            projectIds.addAll(validProjectIds);
         }
 
         return projectIds;
@@ -306,9 +325,7 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
 
             return projectHooks.stream().anyMatch(h -> h.getUrl().equals(gitlabProperties.getWebhookUrl()));
         } catch (GitLabApiException e) {
-            operationalEventService.serviceError(logger, e, "Unable to retrieve project hooks for project {}", projectId);
-
-            throw new GitLabApiRuntimeException(e);
+            throw new GitLabApiRuntimeException(e, "Unable to retrieve project hooks for project " + projectId);
         }
     }
 
@@ -390,12 +407,17 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
      * Generates an ItemBankItemRevision object for a given commit on item.json
      *
      * @param itemBankId item bank item id
-     * @param commit revision information
+     * @param commit     revision information
      * @return ItemBankItemRevision object containing details on the revision
-     * @throws GitLabApiException if there is a problem communicating with GitLab
      */
-    private ItemBankItemRevision generateRevision(int itemBankId, Commit commit, String branch) throws GitLabApiException {
-        RepositoryFile itemFile = gitLabApi.getRepositoryFileApi().getFile(ITEM_FILE_NAME, itemBankId, commit.getId());
+    private ItemBankItemRevision generateRevision(int itemBankId, Commit commit, String branch) {
+        RepositoryFile itemFile;
+        try {
+            itemFile = gitLabApi.getRepositoryFileApi().getFile(ITEM_FILE_NAME, itemBankId, commit.getId());
+        } catch (GitLabApiException e) {
+            throw new GitLabApiRuntimeException(e, String.format("Unexpected error accessing %s for itembank %s", ITEM_FILE_NAME, itemBankId));
+        }
+
         byte json[] = Base64.getDecoder().decode(itemFile.getContent());
         // This will throw a runtime exception if there is a problem converting the item
         Item item = itemParser.readItem(json);

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/client/GitlabHookClient.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/client/GitlabHookClient.java
@@ -19,5 +19,4 @@ public interface GitlabHookClient {
      * @param request Incoming HTTP request
      */
     void handleWebHook(HttpServletRequest request);
-
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/client/ItemBankClient.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/client/ItemBankClient.java
@@ -1,6 +1,7 @@
 package org.opentestsystem.ap.imrt.iis.client;
 
 import org.opentestsystem.ap.imrt.common.model.ItemGitInformation;
+import org.opentestsystem.ap.imrt.iis.exception.GitLabApiRuntimeException;
 import org.opentestsystem.ap.imrt.iis.model.ItemBankItemRevision;
 
 import java.util.List;
@@ -27,12 +28,14 @@ public interface ItemBankClient {
     /**
      * Retrieves the history of an item from the item bank
      *
-     * @param itemBankId the item bank id for the item.
+     * @param itemBankId      the item bank id for the item.
      * @param existingGitInfo Existing itembank info for the item. May be null. If it is not null, only
      *                        history entries since this entry will be returned.
      * @return The list of historical commits
+     * @throws GitLabApiRuntimeException if the itembank id does not contain an item or if there is issues connecting to the item bank
      */
-    List<ItemBankItemRevision> getItemHistory(int itemBankId, ItemGitInformation existingGitInfo);
+    List<ItemBankItemRevision> getItemHistory(int itemBankId, ItemGitInformation existingGitInfo) throws GitLabApiRuntimeException;
+
     /**
      * Get a collection of all item bank identifiers contained in the source control group.
      *
@@ -47,6 +50,7 @@ public interface ItemBankClient {
      * @param projectId The id of the {@link org.gitlab4j.api.models.Project} to investigate
      * @return True if the {@link org.gitlab4j.api.models.Project} has the appropriate webhook to allow it to be
      * monitored for changes; otherwise false.
+     * @throws GitLabApiRuntimeException if there is issues connecting to the item bank
      */
     boolean isProjectMonitored(int projectId);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/controller/GitHookController.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/controller/GitHookController.java
@@ -47,5 +47,4 @@ public class GitHookController {
         gitlabHookClient.handleWebHook(request);
         logger.debug("WebHook Done");
     }
-
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/controller/GlobalExceptionHandler.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/controller/GlobalExceptionHandler.java
@@ -30,8 +30,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * @param request Request the exception was thrown from
      * @return ResponseEntity from the default handler
      */
-    @ExceptionHandler(value = {RuntimeException.class})
-    protected ResponseEntity<Object> handleRuntimeException(RuntimeException ex, WebRequest request) {
+    @ExceptionHandler(value = {Exception.class})
+    protected ResponseEntity<Object> handleRuntimeException(Exception ex, WebRequest request) {
         operationalEventService.serviceError(logger, ex, "Unexpected error processing request");
         return handleException(ex, request);
     }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/exception/GitLabApiRuntimeException.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/exception/GitLabApiRuntimeException.java
@@ -6,19 +6,19 @@ import org.gitlab4j.api.GitLabApiException;
  * Wrapper to create a RuntimeException from a {@link org.gitlab4j.api.GitLabApiException}
  */
 public class GitLabApiRuntimeException extends RuntimeException {
-
-    /**
-     * @param gitLabApiException exception cause
-     */
-    public GitLabApiRuntimeException(GitLabApiException gitLabApiException) {
-        super(gitLabApiException);
-    }
-
     /**
      * @param message message including formatting, using String.format style
      * @param args    arguments to be used in the format processing of the message
      */
     public GitLabApiRuntimeException(String message, Object... args) {
         super(String.format(message, args));
+    }
+
+    /**
+     * @param gitLabApiException the {@link GitLabApiException}
+     * @param message            the message
+     */
+    public GitLabApiRuntimeException(final GitLabApiException gitLabApiException, final String message) {
+        super(message, gitLabApiException);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemDeleteMessageListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemDeleteMessageListener.java
@@ -22,7 +22,7 @@ public class ItemDeleteMessageListener implements ItemMessageListener {
 
     @Override
     public void handleMessage(final Integer itemBankId) {
-        logger.debug("Received item delete message for item bank id: {}", itemBankId);
+        logger.info("Received item delete message for item bank id: {}", itemBankId);
 
         try {
             itemDeleteNotificationHandler.processItemMessage(itemBankId);
@@ -30,5 +30,7 @@ public class ItemDeleteMessageListener implements ItemMessageListener {
             operationalEventService.serviceWarning(logger, e, "Unexpected error when processing item delete for item bank id {}", itemBankId);
             throw e;
         }
+
+        logger.info("Processed item delete message for item bank id: {}", itemBankId);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListener.java
@@ -5,10 +5,7 @@ import org.opentestsystem.ap.imrt.iis.service.ItemUpdateNotificationHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-
-import java.awt.event.ItemListener;
 
 /**
  * Handles processing of item update message listener

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListener.java
@@ -30,7 +30,7 @@ public class ItemUpdateMessageListener implements ItemMessageListener {
      */
     @Override
     public void handleMessage(final Integer itemBankId) {
-        logger.debug("Received item update message for item bank id: {}", itemBankId);
+        logger.info("Received item update message for item bank id: {}", itemBankId);
 
         try {
             itemUpdateNotificationHandler.processItemMessage(itemBankId);
@@ -38,5 +38,7 @@ public class ItemUpdateMessageListener implements ItemMessageListener {
             operationalEventService.serviceWarning(logger, e, "Unexpected error when processing item update for item bank id {}", itemBankId);
             throw e;
         }
+
+        logger.info("Synced item bank id {}", itemBankId);
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemDeleteNotificationHandler.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemDeleteNotificationHandler.java
@@ -45,11 +45,11 @@ public class ItemDeleteNotificationHandler {
 
     @Transactional
     public void processItemMessage(final Integer itemBankId) {
-        logger.info("Received item delete message for {}", itemBankId);
+        logger.info("Received item delete message for itembank id {}", itemBankId);
 
         // get a lock on the project - a project should not be deleted if someone is actively working on it
         final long projectLockId = projectLockService.lockProject(itemBankId);
-        logger.info("Acquired lock for item id {}", itemBankId);
+        logger.debug("Acquired lock for item id {}", itemBankId);
         try {
             final Optional<ItemGitInformation> maybeItemGitInformation =
                     itemGitInformationRepository.findOneByProjectId(itemBankId);

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemDeleteNotificationHandler.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemDeleteNotificationHandler.java
@@ -45,7 +45,7 @@ public class ItemDeleteNotificationHandler {
 
     @Transactional
     public void processItemMessage(final Integer itemBankId) {
-        logger.info("Received item delete message for itembank id {}", itemBankId);
+        logger.debug("Received item delete message for itembank id {}", itemBankId);
 
         // get a lock on the project - a project should not be deleted if someone is actively working on it
         final long projectLockId = projectLockService.lockProject(itemBankId);

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemUpdateNotificationHandler.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemUpdateNotificationHandler.java
@@ -58,7 +58,7 @@ public class ItemUpdateNotificationHandler {
      */
     public void processItemMessage(Integer itemBankId) {
         // TODO use operationalEventService
-        logger.info("Received update message for itembank id {}", itemBankId);
+        logger.debug("Received update message for itembank id {}", itemBankId);
 
         // Lock the project first. Make sure we always unlock it in the finally clause
         long lock = projectLockService.lockProject(itemBankId);
@@ -68,7 +68,7 @@ public class ItemUpdateNotificationHandler {
             // We got the lock, so process the update
             syncItemToItemBank(itemBankId);
             // TODO use operationalEventService
-            logger.info("Synchronization complete for itembankid id {}", itemBankId);
+            logger.debug("Synchronization complete for itembankid id {}", itemBankId);
         } finally {
             projectLockService.unlockProject(itemBankId, lock);
         }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemUpdateNotificationHandler.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemUpdateNotificationHandler.java
@@ -58,17 +58,17 @@ public class ItemUpdateNotificationHandler {
      */
     public void processItemMessage(Integer itemBankId) {
         // TODO use operationalEventService
-        logger.info("Received message for item id {}", itemBankId);
+        logger.info("Received update message for itembank id {}", itemBankId);
 
         // Lock the project first. Make sure we always unlock it in the finally clause
         long lock = projectLockService.lockProject(itemBankId);
         // TODO use operationalEventService
-        logger.info("Acquired lock for item id {}", itemBankId);
+        logger.debug("Acquired lock for item id {}", itemBankId);
         try {
             // We got the lock, so process the update
             syncItemToItemBank(itemBankId);
             // TODO use operationalEventService
-            logger.info("Synchronization complete for item id {}", itemBankId);
+            logger.info("Synchronization complete for itembankid id {}", itemBankId);
         } finally {
             projectLockService.unlockProject(itemBankId, lock);
         }

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImplTest.java
@@ -33,7 +33,6 @@ import org.opentestsystem.ap.imrt.iis.config.ItemBankProperties;
 import org.opentestsystem.ap.imrt.iis.exception.GitLabApiRuntimeException;
 import org.opentestsystem.ap.imrt.iis.model.ItemBankItemRevision;
 import org.opentestsystem.ap.imrt.iis.util.ItemParser;
-import org.slf4j.Logger;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -53,7 +52,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -62,7 +60,8 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT") // Required because findbugs is throwing errors on some of the verify statements
+@SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+// Required because findbugs is throwing errors on some of the verify statements
 public class GitlabClientImplTest {
     private static final String ITEM_FILE_NAME = "item.json";
     private static final String MASTER_BRANCH_NAME = "master";
@@ -97,10 +96,10 @@ public class GitlabClientImplTest {
     private CommitsApi commitsApi;
 
     @Mock
-    private RepositoryFileApi fileApi;
+    private RepositoryFileApi gitlabFileRepository;
 
     @Mock
-    private RepositoryApi repoApi;
+    private RepositoryApi gitlabRepository;
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -113,8 +112,8 @@ public class GitlabClientImplTest {
         client = new GitlabClientImpl(itemBankProperties, operationalEventService, new ItemParser(objectMapper));
         client.setGitLabApi(gitLabApi);
         when(gitLabApi.getCommitsApi()).thenReturn(commitsApi);
-        when(gitLabApi.getRepositoryFileApi()).thenReturn(fileApi);
-        when(gitLabApi.getRepositoryApi()).thenReturn(repoApi);
+        when(gitLabApi.getRepositoryFileApi()).thenReturn(gitlabFileRepository);
+        when(gitLabApi.getRepositoryApi()).thenReturn(gitlabRepository);
         when(existingGitInfo.getItem()).thenReturn(imrtItem);
         when(existingGitInfo.getCurrentCommitDate()).thenReturn(Instant.now());
         existingCommitDate = Date.from(existingGitInfo.getCurrentCommitDate());
@@ -140,7 +139,7 @@ public class GitlabClientImplTest {
         int itemBankId = 77;
         when(commitsApi.getCommits(itemBankId, MASTER_BRANCH_NAME, zeroDate, null, ITEM_FILE_NAME,
                 MAX_ITEMS_PER_PAGE)).thenReturn(emptyCommitPager);
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(null);
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(null);
 
         List<ItemBankItemRevision> result = client.getItemHistory(itemBankId, null);
 
@@ -169,7 +168,7 @@ public class GitlabClientImplTest {
         when(imrtItem.isBeingCreated()).thenReturn(true);
         when(commitsApi.getCommits(itemBankId, MASTER_BRANCH_NAME, existingCommitDate, null, ITEM_FILE_NAME,
                 MAX_ITEMS_PER_PAGE)).thenReturn(emptyCommitPager);
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(null);
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(null);
 
         List<ItemBankItemRevision> result = client.getItemHistory(itemBankId, existingGitInfo);
 
@@ -184,40 +183,38 @@ public class GitlabClientImplTest {
         when(imrtItem.isBeingCreated()).thenReturn(true);
         when(commitsApi.getCommits(itemBankId, MASTER_BRANCH_NAME, existingCommitDate, null, ITEM_FILE_NAME,
                 MAX_ITEMS_PER_PAGE)).thenReturn(emptyCommitPager);
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException("Error"));
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException("Error"));
 
         try {
             client.getItemHistory(itemBankId, existingGitInfo);
             fail();
         } catch (GitLabApiRuntimeException re) {
             assertThat(re.getCause().getMessage()).isEqualTo("Error");
-            verify(operationalEventService).serviceError(any(Logger.class), eq(re.getCause()), eq("Unable to retrieve history for itemBankId {} since {}"),
-                    eq(itemBankId), any(Instant.class));
         }
     }
 
     @Test
     public void historyShouldThrowFindingCreateBranch() throws GitLabApiException {
         int itemBankId = 77;
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException(Response.status(404).build()));
-        when(repoApi.getBranches(itemBankId)).thenReturn(Lists.newArrayList());
+
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException(Response.status(404).build()));
+        when(gitlabRepository.getBranches(itemBankId)).thenReturn(Lists.newArrayList());
 
         try {
             client.getItemHistory(itemBankId, null);
             fail();
         } catch (GitLabApiRuntimeException re) {
             assertThat(re.getMessage()).isEqualTo("Unable to find create_<user> branch for itemBankId " + itemBankId);
-            verify(operationalEventService).serviceError(any(Logger.class), isNull(Throwable.class), eq("Unable to find create_<user> branch for itemBankId {}"),
-                    eq(itemBankId));
         }
     }
+
     @Test
     public void historyShouldUseCreateBranchItemExists() throws GitLabApiException {
         int itemBankId = 77;
         when(imrtItem.isBeingCreated()).thenReturn(true);
         when(commitsApi.getCommits(itemBankId, CREATE_BRANCH_NAME, existingCommitDate, null, ITEM_FILE_NAME,
                 MAX_ITEMS_PER_PAGE)).thenReturn(emptyCommitPager);
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException(Response.status(404).build()));
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException(Response.status(404).build()));
         when(existingGitInfo.getIngestSource()).thenReturn(CREATE_BRANCH_NAME);
 
         List<ItemBankItemRevision> result = client.getItemHistory(itemBankId, existingGitInfo);
@@ -232,11 +229,11 @@ public class GitlabClientImplTest {
         int itemBankId = 77;
         when(commitsApi.getCommits(itemBankId, CREATE_BRANCH_NAME, zeroDate, null, ITEM_FILE_NAME,
                 MAX_ITEMS_PER_PAGE)).thenReturn(emptyCommitPager);
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException(Response.status(404).build()));
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenThrow(new GitLabApiException(Response.status(404).build()));
         when(existingGitInfo.getIngestSource()).thenReturn(CREATE_BRANCH_NAME);
         Branch b = new Branch();
         b.setName(CREATE_BRANCH_NAME);
-        when(repoApi.getBranches(itemBankId)).thenReturn(Lists.newArrayList(b));
+        when(gitlabRepository.getBranches(itemBankId)).thenReturn(Lists.newArrayList(b));
 
         List<ItemBankItemRevision> result = client.getItemHistory(itemBankId, null);
 
@@ -262,7 +259,7 @@ public class GitlabClientImplTest {
 
         RepositoryFile file = new RepositoryFile();
         file.setContent(getBase64EncodedStringFromJsonFile("json/good-item.json"));
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(file);
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(file);
 
         List<ItemBankItemRevision> result = client.getItemHistory(itemBankId, existingGitInfo);
 
@@ -275,7 +272,7 @@ public class GitlabClientImplTest {
                 itemBankId, MASTER_BRANCH_NAME, existingCommitDate, null, ITEM_FILE_NAME, MAX_ITEMS_PER_PAGE);
         verify(pager, times(3)).hasNext();
         verify(pager, times(2)).next();
-        verify(fileApi, times(3)).getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString());
+        verify(gitlabFileRepository, times(3)).getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString());
     }
 
     @Test
@@ -299,8 +296,8 @@ public class GitlabClientImplTest {
         RepositoryFile file = new RepositoryFile();
         file.setContent(getBase64EncodedStringFromJsonFile("json/good-item.json"));
         file.setFilePath(ITEM_BANK_PATH);
-        when(fileApi.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(file);
-        when(fileApi.getFile(ITEM_FILE_NAME, itemBankId, MASTER_BRANCH_NAME)).thenThrow(new GitLabApiException(Response.status(404).build()));
+        when(gitlabFileRepository.getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString())).thenReturn(file);
+        when(gitlabFileRepository.getFile(ITEM_FILE_NAME, itemBankId, MASTER_BRANCH_NAME)).thenThrow(new GitLabApiException(Response.status(404).build()));
 
         List<ItemBankItemRevision> result = client.getItemHistory(itemBankId, existingGitInfo);
 
@@ -313,7 +310,7 @@ public class GitlabClientImplTest {
                 itemBankId, CREATE_BRANCH_NAME, existingCommitDate, null, ITEM_FILE_NAME, MAX_ITEMS_PER_PAGE);
         verify(pager, times(3)).hasNext();
         verify(pager, times(2)).next();
-        verify(fileApi, times(4)).getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString());
+        verify(gitlabFileRepository, times(4)).getFile(eq(ITEM_FILE_NAME), eq(itemBankId), anyString());
     }
 
     /**
@@ -339,7 +336,7 @@ public class GitlabClientImplTest {
     public void shouldThrowExceptionGetCommits() throws GitLabApiException {
         RuntimeException ex = new RuntimeException();
         when(commitsApi.getCommits(99, MASTER_BRANCH_NAME, existingCommitDate, null, ITEM_FILE_NAME, MAX_ITEMS_PER_PAGE))
-            .thenThrow(ex);
+                .thenThrow(ex);
 
         try {
             client.getItemHistory(99, existingGitInfo);
@@ -362,7 +359,7 @@ public class GitlabClientImplTest {
                 .thenReturn(pager);
 
         Exception e = new GitLabApiException("Test");
-        when(fileApi.getFile(ITEM_FILE_NAME, 55, commit.getId())).thenThrow(e);
+        when(gitlabFileRepository.getFile(ITEM_FILE_NAME, 55, commit.getId())).thenThrow(e);
 
         try {
             client.getItemHistory(55, existingGitInfo);


### PR DESCRIPTION
Exceptions were being logged multiple time in the system.  Once in the classes impacted and again at the top of the stack.  Refactored to tighten exception handling and remove double logging.