### PR TITLE
Feature/imrt 431

### DIFF
--- a/src/main/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImpl.java
@@ -207,13 +207,16 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
         Instant since = existingGitInfo != null ? existingGitInfo.getCurrentCommitDate() : Instant.ofEpochSecond(0);
         String branchName = MASTER_BRANCH_NAME;
 
-        if ((null == existingGitInfo
-                || existingGitInfo.getItem().isBeingCreated())
+        if ((null == existingGitInfo || existingGitInfo.getItem().isBeingCreated())
                 && !itemExistsOnMaster(itemBankId)) {
-            // If item.json does not exist on the master branch, find the create branch
-            // TODO - Should this throw or should the calling handler get a Not Found or something to indicate it couldn't find the item?
-            branchName = findCreateBranch(itemBankId, existingGitInfo)
-                    .orElseThrow(() -> new GitLabApiRuntimeException("Unable to find create_<user> branch for itemBankId %s", itemBankId));
+
+            if (existingGitInfo != null) {
+                branchName = existingGitInfo.getIngestSource();
+            } else {
+                // If item.json does not exist on the master branch, find the create branch
+                branchName = findCreateBranch(itemBankId)
+                        .orElseThrow(() -> new GitLabApiRuntimeException("Could not find project for itemBank Id %s", itemBankId));
+            }
         }
 
         logger.debug(LOG, "Using branch {} for itemBankId {}", branchName, itemBankId);
@@ -241,43 +244,6 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
         }
 
         return itemBankItemRevisions;
-    }
-
-    /**
-     * Checks to see if item.json exists on the master branch yet
-     *
-     * @param itemBankId item bank item id
-     * @return true if item.json exists on the master branch, otherwise false
-     * @throws GitLabApiRuntimeException if an unexpected exception occurs
-     */
-    private boolean itemExistsOnMaster(int itemBankId) {
-        return gitLabRepository.findFile(itemBankId, ITEM_FILE_NAME, MASTER_BRANCH_NAME)
-                .isPresent();
-    }
-
-    /**
-     * Find the name of the create_<user> branch for an itemBank item
-     *
-     * @param itemBankId      item bank item id
-     * @param existingGitInfo existing info, may be null
-     * @return the name of the branch
-     */
-    private Optional<String> findCreateBranch(int itemBankId, ItemGitInformation existingGitInfo) {
-        if (null != existingGitInfo) {
-            logger.debug(LOG, "Use existing create branch {} for itemBankId {}", existingGitInfo.getIngestSource(), itemBankId);
-            return Optional.of(existingGitInfo.getIngestSource());
-        }
-
-        List<Branch> branches = gitLabRepository.getAllBranches(itemBankId);
-        for (Branch branch : branches) {
-            if (branch.getName().startsWith(CREATE_BRANCH_PREFIX)) {
-                logger.debug(LOG, "Found create branch {} for itemBankId {}", branch.getName(), itemBankId);
-                return Optional.of(branch.getName());
-            }
-        }
-
-
-        return Optional.empty();
     }
 
     @Override
@@ -313,6 +279,31 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
                 .orElseThrow(() -> new GitLabApiRuntimeException(String.format("Unexpected error getting commit for itemBankId %d and commit hash %s", itemGitInformation.getProjectId(), itemGitInformation.getCurrentCommitHash())));
 
         return generateRevision(itemGitInformation.getProjectId(), commit, itemGitInformation.getIngestSource());
+    }
+
+    @Override
+    public Optional<ItemBankItemRevision> findLatestItemBankItemRevision(final int itemBankId) throws GitLabApiRuntimeException {
+        Optional<RepositoryFile> maybeFile = gitLabRepository.findFile(itemBankId, ITEM_FILE_NAME, MASTER_BRANCH_NAME);
+
+        String branch = MASTER_BRANCH_NAME;
+        if (!maybeFile.isPresent()) {
+            Optional<String> maybeCreateBranch = findCreateBranch(itemBankId);
+            if (!maybeCreateBranch.isPresent()) {
+                return Optional.empty();
+            }
+            branch = maybeCreateBranch.get();
+            maybeFile = gitLabRepository.findFile(itemBankId, ITEM_FILE_NAME, branch);
+
+            if (!maybeFile.isPresent()) {
+                return Optional.empty();
+            }
+        }
+
+        final String commitId = maybeFile.get().getCommitId();
+        Commit commit = gitLabRepository.findCommit(itemBankId, maybeFile.get().getCommitId())
+                .orElseThrow(() -> new GitLabApiRuntimeException("Could not find commit %s for itembank id %s", commitId, itemBankId));
+
+        return Optional.of(generateItemBankItemRevision(itemBankId, commit, branch, maybeFile.get()));
     }
 
     @Override
@@ -400,10 +391,44 @@ public class GitlabClientImpl implements SystemHookListener, WebHookListener, It
         RepositoryFile itemFile = gitLabRepository.findFile(itemBankId, ITEM_FILE_NAME, branch)
                 .orElseThrow(() -> new GitLabApiRuntimeException(String.format("Unexpected error accessing %s for itembank %s", ITEM_FILE_NAME, itemBankId)));
 
+        return generateItemBankItemRevision(itemBankId, commit, branch, itemFile);
+    }
+
+    private ItemBankItemRevision generateItemBankItemRevision(final int itemBankId, final Commit commit, final String branch, final RepositoryFile itemFile) {
         byte json[] = Base64.getDecoder().decode(itemFile.getContent());
         // This will throw a runtime exception if there is a problem converting the item
         Item item = itemParser.readItem(json);
         return new ItemBankItemRevision(itemBankId, gitlabProperties.getGroup(), item, commit.getId(),
                 commit.getCommittedDate().toInstant(), commit.getAuthorName(), !branch.equals(MASTER_BRANCH_NAME), branch);
+    }
+
+    /**
+     * Checks to see if item.json exists on the master branch yet
+     *
+     * @param itemBankId item bank item id
+     * @return true if item.json exists on the master branch, otherwise false
+     * @throws GitLabApiRuntimeException if an unexpected exception occurs
+     */
+    private boolean itemExistsOnMaster(int itemBankId) {
+        return gitLabRepository.findFile(itemBankId, ITEM_FILE_NAME, MASTER_BRANCH_NAME)
+                .isPresent();
+    }
+
+    /**
+     * Find the name of the create_<user> branch for an itemBank item
+     *
+     * @param itemBankId      item bank item id
+     * @return the name of the branch
+     */
+    private Optional<String> findCreateBranch(int itemBankId) {
+        List<Branch> branches = gitLabRepository.getAllBranches(itemBankId);
+        for (Branch branch : branches) {
+            if (branch.getName().startsWith(CREATE_BRANCH_PREFIX)) {
+                logger.debug(LOG, "Found create branch {} for itemBankId {}", branch.getName(), itemBankId);
+                return Optional.of(branch.getName());
+            }
+        }
+
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/client/ItemBankClient.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/client/ItemBankClient.java
@@ -1,11 +1,11 @@
 package org.opentestsystem.ap.imrt.iis.client;
 
-import org.gitlab4j.api.models.Commit;
 import org.opentestsystem.ap.imrt.common.model.ItemGitInformation;
 import org.opentestsystem.ap.imrt.iis.exception.GitLabApiRuntimeException;
 import org.opentestsystem.ap.imrt.iis.model.ItemBankItemRevision;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Interface for Item Bank operations
@@ -64,4 +64,13 @@ public interface ItemBankClient {
      * @return {@link org.opentestsystem.ap.imrt.iis.model.ItemBankItemRevision} object containing details on the revision
      */
     ItemBankItemRevision getItemBankItemRevision(final ItemGitInformation itemGitInformation);
+
+    /**
+     * Finds {@link ItemBankItemRevision} if itembank id contains an item
+     *
+     * @param itemBankId the itembank id
+     * @return the {@link ItemBankItemRevision} if found otherwise empty
+     * @throws GitLabApiRuntimeException if there is an issue getting data from the itembank
+     */
+    Optional<ItemBankItemRevision> findLatestItemBankItemRevision(final int itemBankId) throws GitLabApiRuntimeException;
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListener.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListener.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 /**
  * Handles processing of item update message listener
  */
@@ -34,8 +36,15 @@ public class ItemUpdateMessageListener implements ItemMessageListener {
         logger.debug(LOG, "Received item update message for item bank id: {}", itemBankId);
 
         try {
-            final ItemGitInformation itemGitInformation = itemIngestService.syncItem(itemBankId);
-            logger.info(LOG, "Synced itembank id {}: item id {} to commit hash ", itemBankId, itemGitInformation.getItem().getId(), itemGitInformation.getCurrentCommitHash());
+            final Optional<ItemGitInformation> maybeItemGitInformation = itemIngestService.syncItem(itemBankId);
+
+            if(maybeItemGitInformation.isPresent()) {
+                final ItemGitInformation itemGitInformation = maybeItemGitInformation.get();
+                logger.info(LOG, "Synced itembank id {}: item id {} to commit hash ", itemBankId, itemGitInformation.getItem().getId(), itemGitInformation.getCurrentCommitHash());
+            } else {
+                logger.warn(LOG, null,"Could not find item to process for Itembank {}", itemBankId);
+            }
+
         } catch (Throwable e) {
             logger.warn(LOG, e, "Unexpected error when processing item update for item bank id {}", itemBankId);
             throw e;

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemIngestService.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/ItemIngestService.java
@@ -2,6 +2,8 @@ package org.opentestsystem.ap.imrt.iis.service;
 
 import org.opentestsystem.ap.imrt.common.model.ItemGitInformation;
 
+import java.util.Optional;
+
 public interface ItemIngestService {
     /**
      * Syncs an item with the item bank.  Processes all updates
@@ -9,7 +11,7 @@ public interface ItemIngestService {
      * @param itemBankId the item bank id for the item.
      * @return the most recent {@link ItemGitInformation} containing the current item commit
      */
-    ItemGitInformation syncItem(Integer itemBankId);
+    Optional<ItemGitInformation> syncItem(Integer itemBankId);
 
     /**
      * Update an {@link org.opentestsystem.ap.imrt.common.model.BaseItem} to match the most recent commit.
@@ -18,5 +20,5 @@ public interface ItemIngestService {
      *                           most recent commit to an item.json file.
      * @return the most recent {@link ItemGitInformation} containing the current item commit
      */
-    ItemGitInformation syncItemWithLatestRevision(final ItemGitInformation itemGitInformation);
+    Optional<ItemGitInformation> syncItemWithLatestRevision(final ItemGitInformation itemGitInformation);
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemIngestServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemIngestServiceImpl.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Service responsible for listening on the ite update queue and processing item update
@@ -58,7 +59,7 @@ public class ItemIngestServiceImpl implements ItemIngestService {
     }
 
     @Override
-    public ItemGitInformation syncItem(Integer itemBankId) {
+    public Optional<ItemGitInformation> syncItem(Integer itemBankId) {
         logger.debug(LOG, "Received update message for itembank id {}", itemBankId);
 
         // Lock the project first. Make sure we always unlock it in the finally clause
@@ -75,12 +76,16 @@ public class ItemIngestServiceImpl implements ItemIngestService {
     }
 
     @Override
-    public ItemGitInformation syncItemWithLatestRevision(final ItemGitInformation itemGitInformation) {
+    public Optional<ItemGitInformation> syncItemWithLatestRevision(final ItemGitInformation itemGitInformation) {
         long lock = projectLockService.lockProject(itemGitInformation.getProjectId());
 
         try {
+            if(!containsItem(itemGitInformation.getProjectId())) {
+                return Optional.empty();
+            }
+
             final ItemBankItemRevision itemBankItemRevision = itemBankClient.getItemBankItemRevision(itemGitInformation);
-            return syncItemRevision(itemGitInformation, itemBankItemRevision);
+            return Optional.of(syncItemRevision(itemGitInformation, itemBankItemRevision));
         } finally {
             projectLockService.unlockProject(itemGitInformation.getProjectId(), lock);
         }
@@ -92,7 +97,12 @@ public class ItemIngestServiceImpl implements ItemIngestService {
      *
      * @param itemBankId the item bank id for the item.
      */
-    private ItemGitInformation syncItemToItemBank(int itemBankId) {
+    private Optional<ItemGitInformation> syncItemToItemBank(int itemBankId) {
+        //Verify the itembank has an item to process
+        if(!containsItem(itemBankId)) {
+            return Optional.empty();
+        }
+
         // See if we have any existing itemGitInformation for this item in the database
         ItemGitInformation existingGitInfo = itemGitInformationRepository.findOne(itemBankId);
 
@@ -112,7 +122,9 @@ public class ItemIngestServiceImpl implements ItemIngestService {
             existingGitInfo = syncItemRevision(existingGitInfo, revision);
         }
 
-        return existingGitInfo;
+        //At this point if the existing git info is null it means that there are no commits.  This should not
+        //be possible with Git.
+        return Optional.ofNullable(existingGitInfo);
     }
 
     /**
@@ -143,8 +155,7 @@ public class ItemIngestServiceImpl implements ItemIngestService {
         generateItemEvent(existingGitInfo, revision);
 
         // Update our existing info to what we just saved
-        existingGitInfo = revision.getItemGitInformation();
-        return existingGitInfo;
+        return revision.getItemGitInformation();
     }
 
     /**
@@ -187,4 +198,12 @@ public class ItemIngestServiceImpl implements ItemIngestService {
         return itemHistoryList;
     }
 
+    /**
+     * Checks if the itembank contains an item.  There are itembank repo
+     * @param itemBankId the itembank id to check
+     * @return true if the item contains
+     */
+    private boolean containsItem(int itemBankId) {
+        return itemBankClient.findLatestItemBankItemRevision(itemBankId).isPresent();
+    }
 }

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemMigrationServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemMigrationServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ItemMigrationServiceImpl implements ItemMigrationService {
@@ -49,9 +50,15 @@ public class ItemMigrationServiceImpl implements ItemMigrationService {
                     IterableUtils.toList(itemGitInformationPage.getContent());
             for (final ItemGitInformation itemGitInformation : itemGitInformationList) {
                 try {
-                    final ItemGitInformation currentRevision = itemIngestService.syncItemWithLatestRevision(itemGitInformation);
-                    logger.info(LOG, "Migrated itembank id {}: item id {} to commit hash ", currentRevision.getProjectId(), itemGitInformation.getItem().getId(), itemGitInformation.getCurrentCommitHash());
-                    numberOfItemBankIds++;
+                    final Optional<ItemGitInformation> maybeCurrentRevision = itemIngestService.syncItemWithLatestRevision(itemGitInformation);
+
+                    if (maybeCurrentRevision.isPresent()) {
+                        ItemGitInformation currentRevision = maybeCurrentRevision.get();
+                        logger.info(LOG, "Migrated itembank id {}: item id {} to commit hash ", currentRevision.getProjectId(), itemGitInformation.getItem().getId(), itemGitInformation.getCurrentCommitHash());
+                        numberOfItemBankIds++;
+                    } else {
+                        logger.warn(LOG, null, "Could not migrate itembank {} because it does not have an item", itemGitInformation.getProjectId());
+                    }
                 } catch (final Exception e) {
                     // In this case, we want to continue processing items even if an exception is encountered.
                     // Instead of throwing, the exception will be logged and the migration process will continue.

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/client/GitlabClientImplTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.assertj.core.util.Lists;
 import org.gitlab4j.api.Pager;
-import org.gitlab4j.api.models.Author;
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.Commit;
 import org.gitlab4j.api.models.Namespace;
@@ -196,7 +195,7 @@ public class GitlabClientImplTest {
         } catch (GitLabApiRuntimeException re) {
             verify(mockGitLabRepository).findFile(eq(itemBankId), eq(ITEM_FILE_NAME), anyString());
             verify(mockGitLabRepository).getAllBranches(itemBankId);
-            assertThat(re.getMessage()).isEqualTo("Unable to find create_<user> branch for itemBankId " + itemBankId);
+            assertThat(re.getMessage()).isEqualTo("Could not find project for itemBank Id " + itemBankId);
         }
     }
 
@@ -613,7 +612,82 @@ public class GitlabClientImplTest {
         assertThat(result.getItemBankId()).isEqualTo(itemGitInformation.getProjectId());
     }
 
+    @Test
+    public void shouldFindLatestRevisionOnMaster() throws IOException {
+        Commit commit = new Commit();
+        commit.setId("commitId");
+        commit.setAuthorName("user");
+        Instant now = Instant.now();
+        commit.setCommittedDate(Date.from(now));
 
+        RepositoryFile file = new RepositoryFile();
+        file.setContent(getBase64EncodedStringFromJsonFile("json/good-item.json"));
+        file.setFilePath(ITEM_BANK_PATH);
+        file.setCommitId("commit-1");
+
+        when(mockGitLabRepository.findFile(1, ITEM_FILE_NAME, MASTER_BRANCH_NAME)).thenReturn(Optional.of(file));
+        when(mockGitLabRepository.findCommit(1, file.getCommitId())).thenReturn(Optional.of(commit));
+
+        ItemBankItemRevision revision = client.findLatestItemBankItemRevision(1).get();
+
+        assertThat(revision.getAuthor()).isEqualTo("user");
+        assertThat(revision.getIngestSource()).isEqualTo(MASTER_BRANCH_NAME);
+        assertThat(revision.getItem()).isNotNull();
+        assertThat(revision.getItemBankId()).isEqualTo(1);
+        assertThat(revision.getRevisionId()).isEqualTo("commitId");
+        assertThat(revision.getRevisionDate()).isEqualTo(now);
+    }
+
+    @Test
+    public void shouldFindLatestRevisionOnCreateBranch() throws IOException {
+        Commit commit = new Commit();
+        commit.setId("commitId");
+        commit.setAuthorName("user");
+        Instant now = Instant.now();
+        commit.setCommittedDate(Date.from(now));
+
+        Branch createBranch = new Branch();
+        createBranch.setName(CREATE_BRANCH_NAME);
+
+        RepositoryFile file = new RepositoryFile();
+        file.setContent(getBase64EncodedStringFromJsonFile("json/good-item.json"));
+        file.setFilePath(ITEM_BANK_PATH);
+        file.setCommitId("commit-1");
+
+        when(mockGitLabRepository.findFile(1, ITEM_FILE_NAME, MASTER_BRANCH_NAME)).thenReturn(Optional.empty());
+        when(mockGitLabRepository.getAllBranches(1)).thenReturn(Collections.singletonList(createBranch));
+        when(mockGitLabRepository.findFile(1, ITEM_FILE_NAME, createBranch.getName())).thenReturn(Optional.of(file));
+        when(mockGitLabRepository.findCommit(1, file.getCommitId())).thenReturn(Optional.of(commit));
+
+        ItemBankItemRevision revision = client.findLatestItemBankItemRevision(1).get();
+
+        assertThat(revision.getAuthor()).isEqualTo("user");
+        assertThat(revision.getIngestSource()).isEqualTo(CREATE_BRANCH_NAME);
+        assertThat(revision.getItem()).isNotNull();
+        assertThat(revision.getItemBankId()).isEqualTo(1);
+        assertThat(revision.getRevisionId()).isEqualTo("commitId");
+        assertThat(revision.getRevisionDate()).isEqualTo(now);
+    }
+
+    @Test
+    public void shouldReturnEmptyFindingLatestRevisionWhenNoCreateBranch() {
+        when(mockGitLabRepository.findFile(1, ITEM_FILE_NAME, MASTER_BRANCH_NAME)).thenReturn(Optional.empty());
+        when(mockGitLabRepository.getAllBranches(1)).thenReturn(Collections.emptyList());
+
+        assertThat(client.findLatestItemBankItemRevision(1)).isNotPresent();
+    }
+
+    @Test
+    public void shouldReturnEmptyFindingLatestRevisionNoItemOnAnyBranch(){
+        Branch createBranch = new Branch();
+        createBranch.setName(CREATE_BRANCH_NAME);
+
+        when(mockGitLabRepository.findFile(1, ITEM_FILE_NAME, MASTER_BRANCH_NAME)).thenReturn(Optional.empty());
+        when(mockGitLabRepository.getAllBranches(1)).thenReturn(Collections.singletonList(createBranch));
+        when(mockGitLabRepository.findFile(1, ITEM_FILE_NAME, createBranch.getName())).thenReturn(Optional.empty());
+
+        assertThat(client.findLatestItemBankItemRevision(1)).isNotPresent();
+    }
 
     /**
      * Parse and Item from a json file

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListenerTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/message/ItemUpdateMessageListenerTest.java
@@ -11,6 +11,8 @@ import org.opentestsystem.ap.imrt.common.service.OperationalEventService;
 import org.opentestsystem.ap.imrt.iis.builder.ImrtItemBuilder;
 import org.opentestsystem.ap.imrt.iis.service.ItemIngestService;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
@@ -38,7 +40,7 @@ public class ItemUpdateMessageListenerTest {
         BaseItem item = new ImrtItemBuilder().build();
         mockGitInfo.setItem(item);
 
-        when(mockItemIngestService.syncItem(123)).thenReturn(mockGitInfo);
+        when(mockItemIngestService.syncItem(123)).thenReturn(Optional.of(mockGitInfo));
 
         itemUpdateMessageListener.handleMessage(123);
 

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemIngestServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemIngestServiceImplTest.java
@@ -27,6 +27,8 @@ import org.opentestsystem.ap.imrt.iis.service.ItemRevisionProcessor;
 import org.opentestsystem.ap.imrt.iis.service.ItemRevisionService;
 import org.opentestsystem.ap.imrt.iis.service.ProjectLockService;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -70,7 +72,7 @@ public class ItemIngestServiceImplTest {
 
     private ItemRevision itemRevision;
 
-    private ItemIngestServiceImpl itemUpdateNotificationHandler;
+    private ItemIngestServiceImpl itemIngestService;
 
     @Before
     public void setup() {
@@ -87,7 +89,7 @@ public class ItemIngestServiceImplTest {
                 .withItemLog(new ItemLog())
                 .build();
 
-        itemUpdateNotificationHandler = new ItemIngestServiceImpl(projectLockService, itemBankClient,
+        itemIngestService = new ItemIngestServiceImpl(projectLockService, itemBankClient,
                 itemRevisionService, itemGitInformationRepository, operationalEventService, businessRuleRunner, itemConverter);
     }
 
@@ -95,7 +97,7 @@ public class ItemIngestServiceImplTest {
     public void shouldThrowNoLock() {
         when(projectLockService.lockProject(itemBankId)).thenThrow(new RuntimeException());
         try {
-            itemUpdateNotificationHandler.syncItem(itemBankId);
+            itemIngestService.syncItem(itemBankId);
             fail();
         } catch (RuntimeException e) {
             verifyZeroInteractions(itemBankClient);
@@ -106,12 +108,15 @@ public class ItemIngestServiceImplTest {
 
     @Test
     public void shouldErrorHistoryThrows() {
-        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
         RuntimeException ex = new RuntimeException();
+        ItemBankItemRevision revision = new TestItemBankItemRevisionBuilder().build();
+
+        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
+        when(itemBankClient.findLatestItemBankItemRevision(itemBankId)).thenReturn(Optional.of(revision));
         when(itemBankClient.getItemHistory(anyInt(), any(ItemGitInformation.class))).thenThrow(ex);
 
         try {
-            itemUpdateNotificationHandler.syncItem(itemBankId);
+            itemIngestService.syncItem(itemBankId);
             fail();
         } catch (Throwable e) {
             verify(itemBankClient).getItemHistory(itemBankId, null);
@@ -122,12 +127,15 @@ public class ItemIngestServiceImplTest {
 
     @Test
     public void shouldUseExisting() {
-        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
         ItemGitInformation existing = new TestItemGitBuilder().build();
+        ItemBankItemRevision revision = new TestItemBankItemRevisionBuilder().withRevisionId(existing.getCurrentCommitHash()).build();
+
+        when(itemBankClient.findLatestItemBankItemRevision(itemBankId)).thenReturn(Optional.of(revision));
+        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
         when(itemGitInformationRepository.findOne(itemBankId)).thenReturn(existing);
         when(itemBankClient.getItemHistory(itemBankId, existing)).thenReturn(Lists.newArrayList());
 
-        itemUpdateNotificationHandler.syncItem(itemBankId);
+        itemIngestService.syncItem(itemBankId);
 
         verify(itemBankClient).getItemHistory(itemBankId, existing);
         verify(projectLockService).lockProject(itemBankId);
@@ -136,14 +144,16 @@ public class ItemIngestServiceImplTest {
 
     @Test
     public void shouldRemoveFirstCommit() {
-        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
-        ItemGitInformation existing = new TestItemGitBuilder().build();
-        when(itemGitInformationRepository.findOne(itemBankId)).thenReturn(existing);
         // Make them match so it will be removed
+        ItemGitInformation existing = new TestItemGitBuilder().build();
         ItemBankItemRevision revision = new TestItemBankItemRevisionBuilder().withRevisionId(existing.getCurrentCommitHash()).build();
+
+        when(itemBankClient.findLatestItemBankItemRevision(itemBankId)).thenReturn(Optional.of(revision));
+        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
+        when(itemGitInformationRepository.findOne(itemBankId)).thenReturn(existing);
         when(itemBankClient.getItemHistory(itemBankId, existing)).thenReturn(Lists.newArrayList(revision));
 
-        itemUpdateNotificationHandler.syncItem(itemBankId);
+        itemIngestService.syncItem(itemBankId);
 
         verify(itemBankClient, times(1)).getItemHistory(itemBankId, existing);
         verify(projectLockService, times(1)).lockProject(itemBankId);
@@ -152,19 +162,24 @@ public class ItemIngestServiceImplTest {
 
     @Test
     public void shouldNotRemoveFirstCommitIdsDontMatch() {
-        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
         ImrtItem imrtItem = new ImrtItemBuilder().withKey(3).build();
         ItemGitInformation existing = new TestItemGitBuilder().withImrtItem(imrtItem).build();
-        when(itemGitInformationRepository.findOne(itemBankId)).thenReturn(existing);
-        when(itemConverter.convert(isA(ItemBankItemRevision.class), isA(ItemGitInformation.class))).thenReturn(itemRevision);
 
         ItemBankItemRevision revision = new TestItemBankItemRevisionBuilder()
-                .withRevisionId("hash1").withItem(new StimItem("test stim")).build();
+                .withRevisionId("hash1")
+                .withItem(new StimItem("test stim"))
+                .build();
+
+        when(itemBankClient.findLatestItemBankItemRevision(itemBankId)).thenReturn(Optional.of(revision));
+        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
+        when(itemGitInformationRepository.findOne(itemBankId)).thenReturn(existing);
+        when(itemConverter.convert(isA(ItemBankItemRevision.class), isA(ItemGitInformation.class))).thenReturn(itemRevision);
         when(itemBankClient.getItemHistory(itemBankId, existing)).thenReturn(Lists.newArrayList(revision));
         doAnswer((InvocationOnMock invocationOnMock) -> invocationOnMock.getArgumentAt(1, ItemRevision.class))
-                .when(businessRuleRunner).applyRules(eq(existing), any(ItemRevision.class));
+                .when(businessRuleRunner)
+                .applyRules(eq(existing), any(ItemRevision.class));
 
-        itemUpdateNotificationHandler.syncItem(itemBankId);
+        itemIngestService.syncItem(itemBankId);
 
         verify(itemBankClient).getItemHistory(itemBankId, existing);
         verify(projectLockService).lockProject(itemBankId);
@@ -173,10 +188,14 @@ public class ItemIngestServiceImplTest {
 
     @Test
     public void shouldNotRemoveFirstCommitNoExisting() {
+        ItemBankItemRevision itemBankItemRevision = new TestItemBankItemRevisionBuilder()
+                .withRevisionId("hash1")
+                .withItem(new StimItem("test stim"))
+                .build();
+
+        when(itemBankClient.findLatestItemBankItemRevision(itemBankId)).thenReturn(Optional.of(itemBankItemRevision));
         when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
         when(itemGitInformationRepository.findOne(itemBankId)).thenReturn(null);
-        ItemBankItemRevision itemBankItemRevision = new TestItemBankItemRevisionBuilder()
-                .withRevisionId("hash1").withItem(new StimItem("test stim")).build();
         when(itemBankClient.getItemHistory(itemBankId, null)).thenReturn(Lists.newArrayList(itemBankItemRevision));
         when(itemConverter.convert(isA(ItemBankItemRevision.class), isNull(ItemGitInformation.class))).thenReturn(itemRevision);
 
@@ -191,7 +210,7 @@ public class ItemIngestServiceImplTest {
         doAnswer((InvocationOnMock invocationOnMock) -> invocationOnMock.getArgumentAt(1, ItemRevision.class))
                 .when(businessRuleRunner).applyRules(eq(null), any(ItemRevision.class));
 
-        itemUpdateNotificationHandler.syncItem(itemBankId);
+        itemIngestService.syncItem(itemBankId);
 
         verify(itemBankClient, times(1)).getItemHistory(itemBankId, null);
         verify(projectLockService, times(1)).lockProject(itemBankId);
@@ -207,5 +226,21 @@ public class ItemIngestServiceImplTest {
         assertThat(item).isNotNull();
         assertThat(imrtItem.getKey()).isEqualTo(5);
         verify(projectLockService, times(1)).unlockProject(itemBankId, lockId);
+    }
+
+    @Test
+    public void shouldNotSyncWhenItembankDoesNotContainItem() {
+        ItemGitInformation existing = new TestItemGitBuilder().build();
+
+        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
+        when(itemBankClient.findLatestItemBankItemRevision(itemBankId)).thenReturn(Optional.empty());
+
+        when(itemBankClient.getItemHistory(itemBankId, existing)).thenReturn(Lists.newArrayList());
+
+        assertThat(itemIngestService.syncItem(itemBankId)).isNotPresent();
+
+        verify(itemBankClient, times(0)).getItemHistory(itemBankId, existing);
+        verify(projectLockService).lockProject(itemBankId);
+        verify(projectLockService).unlockProject(itemBankId, lockId);
     }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemIngestServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemIngestServiceImplTest.java
@@ -243,4 +243,17 @@ public class ItemIngestServiceImplTest {
         verify(projectLockService).lockProject(itemBankId);
         verify(projectLockService).unlockProject(itemBankId, lockId);
     }
+
+    @Test
+    public void shouldNotMigrateItemIfItembankDoesNotContainItem() {
+        when(projectLockService.lockProject(itemBankId)).thenReturn(lockId);
+        when(itemBankClient.findLatestItemBankItemRevision(itemBankId)).thenReturn(Optional.empty());
+
+        assertThat(itemIngestService.syncItem(itemBankId)).isNotPresent();
+
+        verify(projectLockService).lockProject(itemBankId);
+        verify(projectLockService).unlockProject(itemBankId, lockId);
+        verifyZeroInteractions(itemRevisionService);
+        verify(itemBankClient, times(0)).getItemBankItemRevision(isA(ItemGitInformation.class));
+    }
 }

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemMigrationServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemMigrationServiceImplTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.isA;
@@ -63,7 +64,7 @@ public class ItemMigrationServiceImplTest {
         when(mockItemGitInformationPage.hasNext()).thenReturn(false);
         when(mockItemGitInformationRepository.findAll(pageRequest))
                 .thenReturn(mockItemGitInformationPage);
-        when(mockItemIngestService.syncItemWithLatestRevision(itemGitInformation)).thenReturn(itemGitInformation);
+        when(mockItemIngestService.syncItemWithLatestRevision(itemGitInformation)).thenReturn(Optional.of(itemGitInformation));
 
         itemMigrationService.migrateAllExistingItems();
 
@@ -87,7 +88,7 @@ public class ItemMigrationServiceImplTest {
                 .thenReturn(nextPageRequest);
         when(mockItemGitInformationRepository.findAll(isA(PageRequest.class)))
                 .thenReturn(mockItemGitInformationPage);
-        when(mockItemIngestService.syncItemWithLatestRevision(itemGitInformation)).thenReturn(itemGitInformation);
+        when(mockItemIngestService.syncItemWithLatestRevision(itemGitInformation)).thenReturn(Optional.of(itemGitInformation));
 
         final ItemMigrationResponse result = itemMigrationService.migrateAllExistingItems();
 
@@ -116,7 +117,9 @@ public class ItemMigrationServiceImplTest {
                 .thenReturn(nextPageRequest);
         when(mockItemGitInformationRepository.findAll(isA(PageRequest.class)))
                 .thenReturn(mockItemGitInformationPage);
-        when(mockItemIngestService.syncItemWithLatestRevision(itemGitInformation)).thenReturn(itemGitInformation).thenThrow(new RuntimeException());
+        when(mockItemIngestService.syncItemWithLatestRevision(itemGitInformation))
+                .thenReturn(Optional.of(itemGitInformation))
+                .thenThrow(new RuntimeException());
 
         final ItemMigrationResponse result = itemMigrationService.migrateAllExistingItems();
 


### PR DESCRIPTION
This changes the logic for item processing where itembank (gitlab repositories) that do not contain an item.json are ignored rather than resulting in an error being logged.

Today if an item.json cannot be found on `master` or `create_ branch` an Exception is thrown and then logged.  This also means that the message is reprocessed since it is currently configured to retry three times on unexpected Exceptions.

Repositories created by IAT that do not have item.json
* glossary
* itembankreport