### PR TITLE
Feature/iat 2049

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ configurations {
 dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.hibernate:hibernate-java8:5.0.12.Final'
-    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.60'
+    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62-SNAPSHOT'
     compile 'org.opentestsystem.ap:ap-common:0.4.15'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.hibernate:hibernate-java8:5.0.12.Final'
     compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62-SNAPSHOT'
-    compile 'org.opentestsystem.ap:ap-common:0.4.17'
+    compile 'org.opentestsystem.ap:ap-common:0.4.20'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-actuator'
     compile 'org.springframework.cloud:spring-cloud-starter-config'

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ configurations {
 dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.hibernate:hibernate-java8:5.0.12.Final'
-    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62-SNAPSHOT'
+    compile 'org.opentestsystem.ap:ap-imrt-common:0.1.62'
     compile 'org.opentestsystem.ap:ap-common:0.4.20'
     compile 'org.springframework.boot:spring-boot-starter-web'
     compile 'org.springframework.boot:spring-boot-starter-actuator'

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemValidationServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemValidationServiceImpl.java
@@ -3,7 +3,9 @@ package org.opentestsystem.ap.imrt.iis.service.impl;
 import org.opentestsystem.ap.common.model.ValidationResults;
 import org.opentestsystem.ap.imrt.common.exception.NotFoundException;
 import org.opentestsystem.ap.imrt.common.model.BaseItem;
+import org.opentestsystem.ap.imrt.common.model.ImrtItem;
 import org.opentestsystem.ap.imrt.common.model.ItemGitInformation;
+import org.opentestsystem.ap.imrt.common.model.Stimulus;
 import org.opentestsystem.ap.imrt.common.model.ValidationResult;
 import org.opentestsystem.ap.imrt.common.repository.ImrtItemRepository;
 import org.opentestsystem.ap.imrt.common.repository.StimulusRepository;
@@ -12,7 +14,6 @@ import org.opentestsystem.ap.imrt.common.service.OperationalEventService;
 import org.opentestsystem.ap.imrt.iis.config.ItemIngestServiceProperties;
 import org.opentestsystem.ap.imrt.iis.repository.ItemGitInformationRepository;
 import org.opentestsystem.ap.imrt.iis.repository.ItemTabulatorRepository;
-import org.opentestsystem.ap.imrt.iis.service.ItemIngestService;
 import org.opentestsystem.ap.imrt.iis.service.ItemValidationService;
 import org.opentestsystem.ap.imrt.iis.service.ProjectLockService;
 import org.slf4j.Logger;
@@ -25,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
@@ -39,7 +39,9 @@ public class ItemValidationServiceImpl implements ItemValidationService {
     private final ItemIngestServiceProperties itemIngestServiceProperties;
     private final OperationalEventService logger;
     private final ProjectLockService projectLockService;
-    private final ItemIngestService itemIngestService;
+    private final ImrtItemRepository imrtItemRepository;
+    private final StimulusRepository stimulusRepository;
+
 
     public ItemValidationServiceImpl(final ValidationResultsRepository validationResultsRepository,
                                      final ItemGitInformationRepository itemGitInformationRepository,
@@ -47,19 +49,22 @@ public class ItemValidationServiceImpl implements ItemValidationService {
                                      final ItemTabulatorRepository itemTabulatorRepository,
                                      final ItemIngestServiceProperties itemIngestServiceProperties,
                                      final ProjectLockService projectLockService,
-                                     final ItemIngestService itemIngestService) {
+                                     final ImrtItemRepository imrtItemRepository,
+                                     final StimulusRepository stimulusRepository) {
         this.validationResultsRepository = validationResultsRepository;
         this.itemGitInformationRepository = itemGitInformationRepository;
         this.itemTabulatorRepository = itemTabulatorRepository;
         this.itemIngestServiceProperties = itemIngestServiceProperties;
         this.logger = logger;
         this.projectLockService = projectLockService;
-        this.itemIngestService = itemIngestService;
+        this.imrtItemRepository = imrtItemRepository;
+        this.stimulusRepository = stimulusRepository;
     }
 
     @Override
     @Transactional
     public void validateItem(final int itemBankId) {
+
         Optional<ItemGitInformation> maybeItemGitInformation = itemGitInformationRepository.findOneByProjectId(itemBankId);
 
         if (!maybeItemGitInformation.isPresent()) {
@@ -68,7 +73,7 @@ public class ItemValidationServiceImpl implements ItemValidationService {
 
         final ItemGitInformation itemGitInformation = maybeItemGitInformation.get();
 
-        if(itemIngestServiceProperties.isIgnoreValidate()) {
+        if (itemIngestServiceProperties.isIgnoreValidate()) {
             logger.debug(LOG, "Ignoring Validation for item {} within item bank id {} and branch {}", itemGitInformation.getItem().getId(), itemGitInformation.getProjectId(), itemGitInformation.getIngestSource());
             return;
         }
@@ -85,14 +90,24 @@ public class ItemValidationServiceImpl implements ItemValidationService {
         validationResultsRepository.save(results);
 
         final BaseItem baseItem = itemGitInformation.getItem();
-        final Map<String, List<ValidationResult>> vallidationResultsGroupedBySeverity = results.stream()
-                .collect(groupingBy(ValidationResult::getSeverity));
+        final Map<String, List<ValidationResult>> validationResultsGroupedBySeverity = results.stream()
+                .collect(groupingBy(result -> result.getSeverity().toLowerCase()));
 
-        baseItem.setSevereValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Severe", Collections.emptyList()).size());
-        baseItem.setDegradedValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Degraded", Collections.emptyList()).size());
-        baseItem.setTolerableValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Tolerable", Collections.emptyList()).size());
-        baseItem.setBenignValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Benign", Collections.emptyList()).size());
+        baseItem.setSevereValidationResultCount(validationResultsGroupedBySeverity.getOrDefault("severe", Collections.emptyList()).size());
+        baseItem.setDegradedValidationResultCount(validationResultsGroupedBySeverity.getOrDefault("degraded", Collections.emptyList()).size());
+        baseItem.setTolerableValidationResultCount(validationResultsGroupedBySeverity.getOrDefault("tolerable", Collections.emptyList()).size());
+        baseItem.setBenignValidationResultCount(validationResultsGroupedBySeverity.getOrDefault("benign", Collections.emptyList()).size());
 
+        final long lockId = projectLockService.lockProject(itemGitInformation.getProjectId());
+        try {
+            if (baseItem instanceof ImrtItem) {
+                imrtItemRepository.save((ImrtItem) baseItem);
+            } else {
+                stimulusRepository.save((Stimulus) baseItem);
+            }
+        } finally {
+            projectLockService.unlockProject(itemGitInformation.getProjectId(), lockId);
+        }
     }
 
     private Collection<ValidationResult> getValidationResults(ItemGitInformation itemGitInformation) {

--- a/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemValidationServiceImpl.java
+++ b/src/main/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemValidationServiceImpl.java
@@ -5,20 +5,30 @@ import org.opentestsystem.ap.imrt.common.exception.NotFoundException;
 import org.opentestsystem.ap.imrt.common.model.BaseItem;
 import org.opentestsystem.ap.imrt.common.model.ItemGitInformation;
 import org.opentestsystem.ap.imrt.common.model.ValidationResult;
+import org.opentestsystem.ap.imrt.common.repository.ImrtItemRepository;
+import org.opentestsystem.ap.imrt.common.repository.StimulusRepository;
 import org.opentestsystem.ap.imrt.common.repository.ValidationResultsRepository;
 import org.opentestsystem.ap.imrt.common.service.OperationalEventService;
 import org.opentestsystem.ap.imrt.iis.config.ItemIngestServiceProperties;
 import org.opentestsystem.ap.imrt.iis.repository.ItemGitInformationRepository;
 import org.opentestsystem.ap.imrt.iis.repository.ItemTabulatorRepository;
+import org.opentestsystem.ap.imrt.iis.service.ItemIngestService;
 import org.opentestsystem.ap.imrt.iis.service.ItemValidationService;
+import org.opentestsystem.ap.imrt.iis.service.ProjectLockService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
 
 @Service
 public class ItemValidationServiceImpl implements ItemValidationService {
@@ -28,17 +38,23 @@ public class ItemValidationServiceImpl implements ItemValidationService {
     private final ItemTabulatorRepository itemTabulatorRepository;
     private final ItemIngestServiceProperties itemIngestServiceProperties;
     private final OperationalEventService logger;
+    private final ProjectLockService projectLockService;
+    private final ItemIngestService itemIngestService;
 
     public ItemValidationServiceImpl(final ValidationResultsRepository validationResultsRepository,
                                      final ItemGitInformationRepository itemGitInformationRepository,
                                      final OperationalEventService logger,
                                      final ItemTabulatorRepository itemTabulatorRepository,
-                                     final ItemIngestServiceProperties itemIngestServiceProperties) {
+                                     final ItemIngestServiceProperties itemIngestServiceProperties,
+                                     final ProjectLockService projectLockService,
+                                     final ItemIngestService itemIngestService) {
         this.validationResultsRepository = validationResultsRepository;
         this.itemGitInformationRepository = itemGitInformationRepository;
         this.itemTabulatorRepository = itemTabulatorRepository;
         this.itemIngestServiceProperties = itemIngestServiceProperties;
         this.logger = logger;
+        this.projectLockService = projectLockService;
+        this.itemIngestService = itemIngestService;
     }
 
     @Override
@@ -62,9 +78,21 @@ public class ItemValidationServiceImpl implements ItemValidationService {
 
         validationResultsRepository.deleteAllByItem(itemGitInformation.getItem());
 
-        if (!results.isEmpty()) {
-            validationResultsRepository.save(results);
+        if (results.isEmpty()) {
+            return;
         }
+
+        validationResultsRepository.save(results);
+
+        final BaseItem baseItem = itemGitInformation.getItem();
+        final Map<String, List<ValidationResult>> vallidationResultsGroupedBySeverity = results.stream()
+                .collect(groupingBy(ValidationResult::getSeverity));
+
+        baseItem.setSevereValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Severe", Collections.emptyList()).size());
+        baseItem.setDegradedValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Degraded", Collections.emptyList()).size());
+        baseItem.setTolerableValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Tolerable", Collections.emptyList()).size());
+        baseItem.setBenignValidationResultCount(vallidationResultsGroupedBySeverity.getOrDefault("Benign", Collections.emptyList()).size());
+
     }
 
     private Collection<ValidationResult> getValidationResults(ItemGitInformation itemGitInformation) {

--- a/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemValidationServiceImplTest.java
+++ b/src/test/java/org/opentestsystem/ap/imrt/iis/service/impl/ItemValidationServiceImplTest.java
@@ -12,6 +12,8 @@ import org.opentestsystem.ap.common.model.ValidationResults;
 import org.opentestsystem.ap.imrt.common.exception.NotFoundException;
 import org.opentestsystem.ap.imrt.common.model.ImrtItem;
 import org.opentestsystem.ap.imrt.common.model.ItemGitInformation;
+import org.opentestsystem.ap.imrt.common.repository.ImrtItemRepository;
+import org.opentestsystem.ap.imrt.common.repository.StimulusRepository;
 import org.opentestsystem.ap.imrt.common.repository.ValidationResultsRepository;
 import org.opentestsystem.ap.imrt.common.service.OperationalEventService;
 import org.opentestsystem.ap.imrt.iis.builder.ImrtItemBuilder;
@@ -19,12 +21,16 @@ import org.opentestsystem.ap.imrt.iis.builder.ItemGitInformationBuilder;
 import org.opentestsystem.ap.imrt.iis.config.ItemIngestServiceProperties;
 import org.opentestsystem.ap.imrt.iis.repository.ItemGitInformationRepository;
 import org.opentestsystem.ap.imrt.iis.repository.ItemTabulatorRepository;
+import org.opentestsystem.ap.imrt.iis.service.ProjectLockService;
 
 import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -41,15 +47,34 @@ public class ItemValidationServiceImplTest {
     @Mock
     private ItemTabulatorRepository mockItemTabulatorRepository;
 
+    @Mock
+    private ImrtItemRepository mockImrtItemRepository;
+
+    @Mock
+    private StimulusRepository mockStimulusRepository;
+
+    @Mock
+    private ProjectLockService mockProjectLockService;
+
     @Captor
     private ArgumentCaptor<Iterable<org.opentestsystem.ap.imrt.common.model.ValidationResult>> validationResultsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ImrtItem> itemCaptor;
 
     private ItemValidationServiceImpl itemValidationService;
 
     @Before
     public void setUp() {
         ItemIngestServiceProperties itemIngestServiceProperties = new ItemIngestServiceProperties();
-        itemValidationService = new ItemValidationServiceImpl(mockValidationResultsRepository, mockItemGitInformationRepository, mockOperationalEventService, mockItemTabulatorRepository, itemIngestServiceProperties);
+        itemValidationService = new ItemValidationServiceImpl(mockValidationResultsRepository,
+                mockItemGitInformationRepository,
+                mockOperationalEventService,
+                mockItemTabulatorRepository,
+                itemIngestServiceProperties,
+                mockProjectLockService,
+                mockImrtItemRepository,
+                mockStimulusRepository);
     }
 
     @Test
@@ -73,15 +98,23 @@ public class ItemValidationServiceImplTest {
 
         when(mockItemGitInformationRepository.findOneByProjectId(1)).thenReturn(Optional.of(itemGitInformation));
         when(mockItemTabulatorRepository.getValidationResults(item.getId(), "master")).thenReturn(Optional.of(results));
+        when(mockProjectLockService.lockProject(itemGitInformation.getProjectId())).thenReturn(42L);
+        doNothing().when(mockProjectLockService).unlockProject(itemGitInformation.getProjectId(), 42L);
+        when(mockImrtItemRepository.save(item)).thenReturn(item);
 
         itemValidationService.validateItem(1);
 
         verify(mockValidationResultsRepository).deleteAllByItem(item);
         verify(mockValidationResultsRepository).save(validationResultsCaptor.capture());
+        verify(mockProjectLockService).lockProject(itemGitInformation.getProjectId());
+        verify(mockImrtItemRepository).save(itemCaptor.capture());
+        verifyZeroInteractions(mockStimulusRepository);
+        verify(mockProjectLockService).unlockProject(itemGitInformation.getProjectId(), 42L);
 
         assertThat(validationResultsCaptor.getValue()).hasSize(1);
 
         org.opentestsystem.ap.imrt.common.model.ValidationResult validationResult = validationResultsCaptor.getValue().iterator().next();
+        final ImrtItem itemWithValidationErrorCounts = itemCaptor.getValue();
 
         assertThat(validationResult.getCategory()).isEqualTo(result.getCategory());
         assertThat(validationResult.getDetail()).isEqualTo(result.getDetail());
@@ -90,6 +123,31 @@ public class ItemValidationServiceImplTest {
         assertThat(validationResult.getValidationItemType()).isEqualTo(result.getItemType());
         assertThat(validationResult.getMessage()).isEqualTo(result.getMessage());
         assertThat(validationResult.getSeverity()).isEqualTo(result.getSeverity());
+        assertThat(itemWithValidationErrorCounts.getSevereValidationResultCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldNotUpdateValidationErrorCountsWhenThereAreNoValidationErrors() {
+        ImrtItem item = new ImrtItemBuilder().build();
+        ItemGitInformation itemGitInformation = new ItemGitInformationBuilder()
+                .withProjectId(1)
+                .withItem(item)
+                .withIngestSource("master")
+                .build();
+        final ValidationResults validationResults = new ValidationResults();
+        validationResults.setValidationResults(Collections.emptyList());
+
+        when(mockItemGitInformationRepository.findOneByProjectId(1)).thenReturn(Optional.of(itemGitInformation));
+        when(mockItemGitInformationRepository.findOneByProjectId(1)).thenReturn(Optional.of(itemGitInformation));
+        when(mockItemTabulatorRepository.getValidationResults(item.getId(), "master")).thenReturn(Optional.of(validationResults));
+
+        itemValidationService.validateItem(1);
+
+        verify(mockValidationResultsRepository).deleteAllByItem(item);
+        verify(mockValidationResultsRepository, never()).save(validationResultsCaptor.capture());
+        verifyZeroInteractions(mockProjectLockService);
+        verifyZeroInteractions(mockImrtItemRepository);
+        verifyZeroInteractions(mockStimulusRepository);
     }
 
     @Test(expected = NotFoundException.class)


### PR DESCRIPTION
[IAT-2049](https://jira.fairwaytech.com/browse/IAT-2049):  Add fields for validation results count fields.

### Additional Notes
After testing a query that would get the counts from the `validation_result` table for each of the severity levels, I decided it would be better to store the counts whenever the item is submitted to the validation service.