### PR TITLE
Set logging during bootstrap phase when running in local-development …

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -12,3 +12,9 @@ spring:
         max-attempts: ${CS_RETRY_MAX_ATTEMPTS:25}
         max-interval: ${CS_RETRY_MAX_INTERVAL:4000}
         multiplier: ${CS_RETRY_MULTIPLIER:1.2}
+
+---
+spring:
+  profiles: local-development
+logging:
+  config: classpath:log4j2-local.xml


### PR DESCRIPTION
…mode

Right now we have slow startups when running in local-development since the default logging configuration is used during the bootstrap phase.