### PR TITLE
Prepare for docker-compose and CI environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,16 +249,19 @@ task dockerCopyFiles(type: Copy) {
 task dockerBuildImage(type: DockerBuildImage) {
     dependsOn 'dockerCopyFiles'
     inputDir = project.file('build/docker/')
-    tag = "${dockerTagBase}/${jar.baseName}:${version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    tags.add(name.toString())
 }
 
 task dockerPushImage(type: DockerPushImage) {
     dependsOn 'dockerBuildImage'
-    imageName = "${dockerTagBase}/${jar.baseName}:${version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    imageName = name.toString()
 }
 
 task dockerRemoveImage(type: DockerRemoveImage) {
-    imageId = "${project.dockerTagBase}/${jar.baseName}:${project.version}"
+    def name = "${dockerTagBase}/${project.name}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    imageId = name.toString()
 }
 
 /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
   datasource:
     url: "jdbc:postgresql://localhost:5432/imrt"
+    username: ${IMRT_DB_USER}
+    password: ${IMRT_DB_PASSWORD}
   batch:
     job:
       enabled: false # Prevent Spring from starting jobs on startup.


### PR DESCRIPTION
I had to add a path for injecting IMRT username/pass from environment variables through a docker-compose.

Sample docker-compose:
```
  # IMRT Item Ingest Service
  ap-imrt-iis:
    image: fwsbac/ap-imrt-iis:latest
    ports:
      - 9081:9081
    environment:
      - SPRING_RABBITMQ_HOST=host.docker.internal
      - SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5432/imrt
      - IMRT_DB_USER
      - IMRT_DB_PASSWORD
      - GITLAB_HOST
      - GITLAB_GROUP
      - GITLAB_ACCESS_TOKEN
      - GITLAB_WEBHOOK_URL
```