### PR TITLE
Fix hibernate item json deserialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile 'org.postgresql:postgresql:42.2.1'
     // Type mappings for hibernate -> PostgreSQL Json
     compile 'biz.paluch.logging:logstash-gelf:1.12.0'
-    compile 'com.vladmihalcea:hibernate-types-5:2.0.0'
+    compile 'com.vladmihalcea:hibernate-types-5:2.2.0'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/resources/hibernate-types.properties
+++ b/src/main/resources/hibernate-types.properties
@@ -1,0 +1,1 @@
+hibernate.types.jackson.object.mapper=org.opentestsystem.ap.common.model.ModelObjectMapper


### PR DESCRIPTION
We needed to bump the hibernate-types library version to allow us to configure the hibernate json ObjectMapper instance.